### PR TITLE
tools: add `tox` to handle the project test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "econnect-alarm"
 dynamic = ["version"]
 description = "Home Assistant integration that provides a full-fledged Alarm Panel to control your Elmo alarm system."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 keywords = [
   "python",
@@ -23,12 +23,8 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
   "homeassistant",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist =
+    lint
+    py3.11
+
+[testenv]
+allowlist_externals = pytest
+deps =
+    -e .[dev]
+commands =
+    pytest tests/ --cov custom_components -v
+
+[testenv:lint]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
### Related Issues

- Closes #5 

### Proposed Changes:

Ensure that the the project's Python version matches the one used in Home Assistant. To simplify the tooling, `tox` is used to run linting and tests.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
