### PR TITLE
tools: add `hassfest` GitHub actions to validate the integration

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,26 @@
+name: Validate with hassfest
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Test hassfest
+        uses: home-assistant/actions/hassfest@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: end-of-file-fixer
+      exclude: custom_components/econnect_alarm/manifest.json
     - id: mixed-line-ending
     - id: trailing-whitespace
 

--- a/custom_components/econnect_alarm/manifest.json
+++ b/custom_components/econnect_alarm/manifest.json
@@ -1,15 +1,21 @@
 {
   "domain": "econnect_alarm",
   "name": "E-connect Alarm",
-  "version": "0.0.5",
+  "after_dependencies": [],
+  "codeowners": [
+    "@palazzem"
+  ],
   "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/palazzem/ha-econnect-alarm",
+  "integration_type": "device",
   "iot_class": "cloud_polling",
-  "documentation": "https://www.home-assistant.io/integrations/econnect_alarm",
+  "issue_tracker": "https://github.com/palazzem/ha-econnect-alarm/issues",
+  "loggers": [
+    "custom_components.econnect_alarm"
+  ],
   "requirements": [
     "econnect-python==0.5.1"
   ],
-  "dependencies": [],
-  "codeowners": [
-    "@palazzem"
-  ]
+  "version": "0.0.5"
 }


### PR DESCRIPTION
### Related Issues

- Closes #17 

### Proposed Changes:

Validate the integration using [hassfest Github Action](https://github.com/home-assistant/actions). Through this GitHub actions we're sure the integration supports properly the latest version of Home Assistant.

### Testing:

This test runs on every merge, PR and on a daily basis.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
