### PR TITLE
fix(ci): builder action names the package with the right version using `hatch version`

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -35,10 +35,10 @@ jobs:
         run: hatch -v build -t sdist
 
       - name: Log package content
-        run: tar -tvf dist/*.tar.gz
+        run: tar -tvf dist/econnect_alarm-$(hatch version).tar.gz
 
       - name: Install the package
-        run: pip install dist/*.tar.gz
+        run: pip install dist/econnect_alarm-$(hatch version).tar.gz
 
       - name: Test if the package is built correctly
         run: python -c "import custom_components.econnect_alarm"
@@ -46,5 +46,5 @@ jobs:
       - name: Upload release archive
         uses: actions/upload-artifact@v3
         with:
-          name: econnect-alarm-{{ github.ref_name }}
-          path: dist/*.tar.gz
+          name: econnect-alarm-$(hatch version).tar.gz
+          path: dist/econnect_alarm-$(hatch version).tar.gz

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   econnect:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   econnect:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TOX_SKIP_ENV: lint
 


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

- Fix the builder action names the package with the right version using `hatch version`
- Update all GitHub actions to `ubuntu-latest`

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
