### PR TITLE
feat: add `AlarmDevice` component

### DIFF
--- a/custom_components/econnect_alarm/__init__.py
+++ b/custom_components/econnect_alarm/__init__.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import async_timeout
 from elmo.api.client import ElmoClient
 from elmo.api.exceptions import InvalidToken
-from elmo.devices import AlarmDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -22,6 +21,7 @@ from .const import (
     POLLING_TIMEOUT,
     SCAN_INTERVAL,
 )
+from .devices import AlarmDevice
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/econnect_alarm/devices.py
+++ b/custom_components/econnect_alarm/devices.py
@@ -1,0 +1,150 @@
+import logging
+
+from elmo import query as q
+from elmo.api.exceptions import CodeError, CredentialError, LockError, ParseError
+from elmo.utils import _filter_data
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_DISARMED,
+    STATE_UNAVAILABLE,
+)
+from requests.exceptions import HTTPError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AlarmDevice:
+    """AlarmDevice class represents an e-connect alarm system. This method wraps around
+    a connector object (e.g. `ElmoClient`) so that the client can be stateless and just
+    return data, while this class persists the status of the alarm.
+
+    Usage:
+        # Initialization
+        conn = ElmoClient()
+        device = AlarmDevice(conn)
+
+        # Connect automatically grab the latest status
+        device.connect("username", "password")
+        print(device.state)
+    """
+
+    def __init__(self, connection):
+        # Configuration and internals
+        self._connection = connection
+        self._lastIds = {
+            q.SECTORS: 0,
+            q.INPUTS: 0,
+        }
+
+        # Alarm state
+        self.state = STATE_UNAVAILABLE
+        self.sectors_armed = {}
+        self.sectors_disarmed = {}
+        self.inputs_alerted = {}
+        self.inputs_wait = {}
+
+    def connect(self, username, password):
+        """Establish a connection with the E-connect backend, to retrieve an access
+        token. This method stores the `session_id` within the `ElmoClient` object
+        and is used automatically when other methods are called.
+
+        When a connection is successfully established, the device automatically
+        updates the status calling `self.update()`.
+        """
+        try:
+            self._connection.auth(username, password)
+        except HTTPError as err:
+            _LOGGER.error(f"Device | Error while authenticating with e-Connect: {err}")
+            raise err
+        except CredentialError as err:
+            _LOGGER.error(f"Device | Username or password are not correct: {err}")
+            raise err
+
+    def has_updates(self):
+        """Use the connection to detect a possible change. This is a blocking call
+        that must not be called in the main thread. Check `ElmoClient.poll()` method
+        for more details.
+
+        Values passed to `ElmoClient.poll()` are the last known IDs for sectors and
+        inputs. A new dictionary is sent to avoid the underlying client to mutate
+        the device internal state.
+        """
+        try:
+            return self._connection.poll({x: y for x, y in self._lastIds.items()})
+        except HTTPError as err:
+            _LOGGER.error(f"Device | Error while checking if there are updates: {err}")
+            raise err
+        except ParseError as err:
+            _LOGGER.error(f"Device | Error parsing the poll response: {err}")
+            raise err
+
+    def update(self):
+        """Updates the internal state of the device based on the latest data.
+
+        This method performs the following actions:
+        1. Queries for the latest sectors and inputs using the internal connection.
+        2. Filters the retrieved sectors and inputs to categorize them based on their status.
+        3. Updates the last known IDs for sectors and inputs.
+        4. Updates internal state for sectors' and inputs' statuses.
+
+        Raises:
+            HTTPError: If there's an error while making the HTTP request.
+            ParseError: If there's an error while parsing the response.
+
+        Attributes updated:
+            sectors_armed (dict): A dictionary of sectors that are armed.
+            sectors_disarmed (dict): A dictionary of sectors that are disarmed.
+            inputs_alerted (dict): A dictionary of inputs that are in an alerted state.
+            inputs_wait (dict): A dictionary of inputs that are in a wait state.
+            _lastIds (dict): Updated last known IDs for sectors and inputs.
+            state (str): Updated internal state of the device.
+        """
+        # Retrieve sectors and inputs
+        try:
+            sectors = self._connection.query(q.SECTORS)
+            inputs = self._connection.query(q.INPUTS)
+        except (HTTPError, ParseError) as err:
+            _LOGGER.error(f"Device | Error while checking if there are updates: {err}")
+            raise
+
+        # Filter sectors and inputs
+        self.sectors_armed = _filter_data(sectors, "sectors", True)
+        self.sectors_disarmed = _filter_data(sectors, "sectors", False)
+        self.inputs_alerted = _filter_data(inputs, "inputs", True)
+        self.inputs_wait = _filter_data(inputs, "inputs", False)
+
+        self._lastIds[q.SECTORS] = sectors.get("last_id", 0)
+        self._lastIds[q.INPUTS] = inputs.get("last_id", 0)
+
+        # Update the internal state machine
+        self.state = STATE_ALARM_ARMED_AWAY if self.sectors_armed else STATE_ALARM_DISARMED
+
+    def arm(self, code, sectors=None):
+        try:
+            with self._connection.lock(code):
+                self._connection.arm(sectors=sectors)
+                self.state = STATE_ALARM_ARMED_AWAY
+        except HTTPError as err:
+            _LOGGER.error(f"Device | Error while arming the system: {err}")
+            raise err
+        except LockError as err:
+            _LOGGER.error(f"Device | Error while acquiring the system lock: {err}")
+            raise err
+        except CodeError as err:
+            _LOGGER.error(f"Device | Credentials (alarm code) is incorrect: {err}")
+            raise err
+
+    def disarm(self, code, sectors=None):
+        try:
+            with self._connection.lock(code):
+                self._connection.disarm(sectors=sectors)
+                self.state = STATE_ALARM_DISARMED
+        except HTTPError as err:
+            _LOGGER.error(f"Device | Error while disarming the system: {err}")
+            raise err
+        except LockError as err:
+            _LOGGER.error(f"Device | Error while acquiring the system lock: {err}")
+            raise err
+        except CodeError as err:
+            _LOGGER.error(f"Device | Credentials (alarm code) is incorrect: {err}")
+            raise err

--- a/custom_components/econnect_alarm/manifest.json
+++ b/custom_components/econnect_alarm/manifest.json
@@ -15,7 +15,7 @@
     "custom_components.econnect_alarm"
   ],
   "requirements": [
-    "econnect-python==0.5.1"
+    "econnect-python==0.6.0"
   ],
   "version": "0.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
   "homeassistant",
-  "econnect-python==0.5.1",
+  "econnect-python==0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-mock",
+  "responses",
   "tox",
   # Home Assistant fixtures
   "freezegun",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 import responses
 from elmo.api.client import ElmoClient
-from fixtures import responses as r
+
+from .fixtures import responses as r
 
 pytest_plugins = ["tests.hass.fixtures"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 import pytest
+import responses
+from elmo.api.client import ElmoClient
+from fixtures import responses as r
 
 pytest_plugins = ["tests.hass.fixtures"]
 
@@ -7,3 +10,30 @@ pytest_plugins = ["tests.hass.fixtures"]
 async def hass(hass):
     hass.data["custom_components"] = None
     yield hass
+
+
+@pytest.fixture(scope="function")
+def client():
+    """Creates an instance of `ElmoClient` which emulates the behavior of a real client for
+    testing purposes.
+
+    Although this client instance operates with mocked calls, it is designed to function as
+    if it were genuine. This ensures that the client's usage in tests accurately mirrors how it
+    would be employed in real scenarios.
+
+    Use it for integration tests where a realistic interaction with the `ElmoClient` is required
+    without actual external calls.
+    """
+    client = ElmoClient(base_url="https://example.com", domain="domain")
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as server:
+        server.add(responses.GET, "https://example.com/api/login", body=r.LOGIN, status=200)
+        server.add(responses.POST, "https://example.com/api/updates", body=r.UPDATES, status=200)
+        server.add(responses.POST, "https://example.com/api/panel/syncLogin", body=r.SYNC_LOGIN, status=200)
+        server.add(responses.POST, "https://example.com/api/panel/syncLogout", body=r.SYNC_LOGOUT, status=200)
+        server.add(
+            responses.POST, "https://example.com/api/panel/syncSendCommand", body=r.SYNC_SEND_COMMAND, status=200
+        )
+        server.add(responses.POST, "https://example.com/api/strings", body=r.STRINGS, status=200)
+        server.add(responses.POST, "https://example.com/api/areas", body=r.AREAS, status=200)
+        server.add(responses.POST, "https://example.com/api/inputs", body=r.INPUTS, status=200)
+        yield client

--- a/tests/fixtures/responses.py
+++ b/tests/fixtures/responses.py
@@ -1,0 +1,242 @@
+"""
+Centralizes predefined responses intended for integration testing, especially when used with the `server` fixture.
+For standard tests, responses should be encapsulated within the test itself. This module should be referenced
+primarily when updating the responses for the integration test client, ensuring a consistent test environment.
+
+Key Benefits:
+    - Central repository of standardized test responses.
+    - Promotes consistent and maintainable testing practices.
+
+Usage:
+    1. Import the required response constant from this module:
+       from tests.fixtures.responses import SECTORS
+
+    2. Incorporate the imported response in your test logic:
+       def test_client_get_sectors_status(server):
+           server.add(responses.POST, "https://example.com/api/areas", body=SECTORS, status=200)
+           # Continue with the test...
+"""
+
+
+LOGIN = """
+    {
+        "SessionId": "00000000-0000-0000-0000-000000000000",
+        "Username": "test",
+        "Domain": "domain",
+        "Language": "en",
+        "IsActivated": true,
+        "IsConnected": true,
+        "IsLoggedIn": false,
+        "IsLoginInProgress": false,
+        "CanElevate": true,
+        "AccountId": 100,
+        "IsManaged": false,
+        "Redirect": false,
+        "IsElevation": false
+    }
+"""
+UPDATES = """
+    {
+        "ConnectionStatus": false,
+        "CanElevate": false,
+        "LoggedIn": false,
+        "LoginInProgress": false,
+        "Areas": true,
+        "Events": false,
+        "Inputs": true,
+        "Outputs": false,
+        "Anomalies": false,
+        "ReadStringsInProgress": false,
+        "ReadStringPercentage": 0,
+        "Strings": 0,
+        "ManagedAccounts": false,
+        "Temperature": false,
+        "StatusAdv": false,
+        "Images": false,
+        "AdditionalInfoSupported": true,
+        "HasChanges": true
+    }
+"""
+SYNC_LOGIN = """[
+    {
+        "Poller": {"Poller": 1, "Panel": 1},
+        "CommandId": 5,
+        "Successful": true
+    }
+]"""
+SYNC_LOGOUT = """[
+    {
+        "Poller": {"Poller": 1, "Panel": 1},
+        "CommandId": 5,
+        "Successful": true
+    }
+]"""
+SYNC_SEND_COMMAND = """[
+    {
+        "Poller": {"Poller": 1, "Panel": 1},
+        "CommandId": 5,
+        "Successful": true
+    }
+]"""
+STRINGS = """[
+    {
+        "AccountId": 1,
+        "Class": 9,
+        "Index": 0,
+        "Description": "S1 Living Room",
+        "Created": "/Date(1546004120767+0100)/",
+        "Version": "AAAAAAAAgPc="
+    },
+    {
+        "AccountId": 1,
+        "Class": 9,
+        "Index": 1,
+        "Description": "S2 Bedroom",
+        "Created": "/Date(1546004120770+0100)/",
+        "Version": "AAAAAAAAgPg="
+    },
+    {
+        "AccountId": 1,
+        "Class": 9,
+        "Index": 2,
+        "Description": "S3 Outdoor",
+        "Created": "/Date(1546004147490+0100)/",
+        "Version": "AAAAAAAAgRs="
+    },
+    {
+        "AccountId": 1,
+        "Class": 10,
+        "Index": 0,
+        "Description": "Entryway Sensor",
+        "Created": "/Date(1546004147493+0100)/",
+        "Version": "AAAAAAAAgRw="
+    },
+    {
+        "AccountId": 1,
+        "Class": 10,
+        "Index": 1,
+        "Description": "Outdoor Sensor 1",
+        "Created": "/Date(1546004147493+0100)/",
+        "Version": "AAAAAAAAgRw="
+    },
+    {
+        "AccountId": 1,
+        "Class": 10,
+        "Index": 2,
+        "Description": "Outdoor Sensor 2",
+        "Created": "/Date(1546004147493+0100)/",
+        "Version": "AAAAAAAAgRw="
+    },
+    {
+        "AccountId": 3,
+        "Class": 10,
+        "Index": 3,
+        "Description": "Outdoor Sensor 3",
+        "Created": "/Date(1546004147493+0100)/",
+        "Version": "AAAAAAAAgRw="
+    }
+]"""
+AREAS = """[
+   {
+       "Active": true,
+       "ActivePartial": false,
+       "Max": false,
+       "Activable": true,
+       "ActivablePartial": false,
+       "InUse": true,
+       "Id": 1,
+       "Index": 0,
+       "Element": 1,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Active": true,
+       "ActivePartial": false,
+       "Max": false,
+       "Activable": true,
+       "ActivablePartial": false,
+       "InUse": true,
+       "Id": 2,
+       "Index": 1,
+       "Element": 2,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Active": false,
+       "ActivePartial": false,
+       "Max": false,
+       "Activable": true,
+       "ActivablePartial": false,
+       "InUse": true,
+       "Id": 3,
+       "Index": 2,
+       "Element": 3,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Active": false,
+       "ActivePartial": false,
+       "Max": false,
+       "Activable": true,
+       "ActivablePartial": false,
+       "InUse": false,
+       "Id": 4,
+       "Index": 3,
+       "Element": 5,
+       "CommandId": 0,
+       "InProgress": false
+   }
+]"""
+INPUTS = """[
+   {
+       "Alarm": true,
+       "MemoryAlarm": false,
+       "Excluded": false,
+       "InUse": true,
+       "IsVideo": false,
+       "Id": 1,
+       "Index": 0,
+       "Element": 1,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Alarm": true,
+       "MemoryAlarm": false,
+       "Excluded": false,
+       "InUse": true,
+       "IsVideo": false,
+       "Id": 2,
+       "Index": 1,
+       "Element": 2,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Alarm": false,
+       "MemoryAlarm": false,
+       "Excluded": true,
+       "InUse": true,
+       "IsVideo": false,
+       "Id": 3,
+       "Index": 2,
+       "Element": 3,
+       "CommandId": 0,
+       "InProgress": false
+   },
+   {
+       "Alarm": false,
+       "MemoryAlarm": false,
+       "Excluded": false,
+       "InUse": false,
+       "IsVideo": false,
+       "Id": 42,
+       "Index": 3,
+       "Element": 4,
+       "CommandId": 0,
+       "InProgress": false
+   }
+]"""

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,331 @@
+import pytest
+from elmo import query as q
+from elmo.api.exceptions import CodeError, CredentialError, LockError, ParseError
+from requests.exceptions import HTTPError
+
+from custom_components.econnect_alarm.devices import AlarmDevice
+
+
+def test_device_constructor(client):
+    """Should initialize defaults attributes to run properly."""
+    device = AlarmDevice(connection=client)
+    # Test
+    assert device._connection == client
+    assert device._lastIds == {q.SECTORS: 0, q.INPUTS: 0}
+    assert device.state == "unavailable"
+    assert device.sectors_armed == {}
+    assert device.sectors_disarmed == {}
+    assert device.inputs_alerted == {}
+    assert device.inputs_wait == {}
+
+
+def test_device_connect(client, mocker):
+    """Should call authentication endpoints and update internal state."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "auth")
+    # Test
+    device.connect("username", "password")
+    assert device._connection.auth.call_count == 1
+    assert "username" == device._connection.auth.call_args[0][0]
+    assert "password" == device._connection.auth.call_args[0][1]
+
+
+def test_device_connect_error(client, mocker):
+    """Should handle (log) authentication errors (not 2xx)."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "auth")
+    device._connection.auth.side_effect = HTTPError("Unable to communicate with e-Connect")
+    # Test
+    with pytest.raises(HTTPError):
+        device.connect("username", "password")
+    assert device._connection.auth.call_count == 1
+
+
+def test_device_connect_credential_error(client, mocker):
+    """Should handle (log) credential errors (401/403)."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "auth")
+    device._connection.auth.side_effect = CredentialError("Incorrect username and/or password")
+    # Test
+    with pytest.raises(CredentialError):
+        device.connect("username", "password")
+    assert device._connection.auth.call_count == 1
+
+
+def test_device_has_updates(client, mocker):
+    """Should call the client polling system passing the internal state."""
+    device = AlarmDevice(connection=client)
+    device.connect("username", "password")
+    device._lastIds[q.SECTORS] = 20
+    device._lastIds[q.INPUTS] = 20
+    mocker.spy(device._connection, "poll")
+    # Test
+    device.has_updates()
+    assert device._connection.poll.call_count == 1
+    assert {9: 20, 10: 20} in device._connection.poll.call_args[0]
+
+
+def test_device_has_updates_ids_immutable(client, mocker):
+    """Device internal ids must be immutable."""
+
+    def bad_poll(ids):
+        ids[q.SECTORS] = 0
+        ids[q.INPUTS] = 0
+
+    device = AlarmDevice(connection=client)
+    device._lastIds = {q.SECTORS: 4, q.INPUTS: 42}
+    mocker.patch.object(device._connection, "poll")
+    device._connection.poll.side_effect = bad_poll
+    # Test
+    device.has_updates()
+    assert device._connection.poll.call_count == 1
+    assert {9: 4, 10: 42} == device._lastIds
+
+
+def test_device_has_updates_errors(client, mocker):
+    """Should handle (log) polling errors."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "poll")
+    device._connection.poll.side_effect = HTTPError("Unable to communicate with e-Connect")
+    # Test
+    with pytest.raises(HTTPError):
+        device.has_updates()
+    assert device._connection.poll.call_count == 1
+    assert {9: 0, 10: 0} == device._lastIds
+
+
+def test_device_has_updates_parse_errors(client, mocker):
+    """Should handle (log) polling errors."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "poll")
+    device._connection.poll.side_effect = ParseError("Error parsing the poll response")
+    # Test
+    with pytest.raises(ParseError):
+        device.has_updates()
+    assert device._connection.poll.call_count == 1
+    assert {9: 0, 10: 0} == device._lastIds
+
+
+def test_device_update_success(client, mocker):
+    """Should check store the e-connect System status in the device object."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "query")
+    sectors_armed = {
+        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
+        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
+    }
+    sectors_disarmed = {
+        2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": False, "name": "S3 Outdoor"}
+    }
+    inputs_alerted = {
+        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "Entryway Sensor"},
+        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "Outdoor Sensor 1"},
+    }
+    inputs_wait = {
+        2: {"id": 3, "index": 2, "element": 3, "excluded": True, "status": False, "name": "Outdoor Sensor 2"}
+    }
+    device.connect("username", "password")
+    # Test
+    device.update()
+    assert device._connection.query.call_count == 2
+    assert device.sectors_armed == sectors_armed
+    assert device.sectors_disarmed == sectors_disarmed
+    assert device.inputs_alerted == inputs_alerted
+    assert device.inputs_wait == inputs_wait
+    assert device._lastIds == {
+        q.SECTORS: 4,
+        q.INPUTS: 42,
+    }
+
+
+def test_device_update_http_error(client, mocker):
+    """Tests if device's update method raises HTTPError when querying."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "query", side_effect=HTTPError("HTTP Error"))
+    with pytest.raises(HTTPError):
+        device.update()
+
+
+def test_device_update_parse_error(client, mocker):
+    """Tests if update method raises ParseError when querying."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "query", side_effect=ParseError("Parse Error"))
+    with pytest.raises(ParseError):
+        device.update()
+
+
+def test_device_update_state_machine_armed(client, mocker):
+    """Should check if the state machine is properly updated after calling update()."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "query")
+    device._connection.query.side_effect = [
+        {
+            "last_id": 3,
+            "sectors": {
+                0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
+                1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
+                2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": False, "name": "S3 Outdoor"},
+            },
+        },
+        {
+            "last_id": 3,
+            "inputs": {
+                0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "Entryway Sensor"},
+                1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "Outdoor Sensor 1"},
+                2: {"id": 3, "index": 2, "element": 3, "excluded": True, "status": False, "name": "Outdoor Sensor 2"},
+            },
+        },
+    ]
+    # Test
+    device.update()
+    assert device.state == "armed_away"
+
+
+def test_device_update_state_machine_disarmed(client, mocker):
+    """Should check if the state machine is properly updated after calling update()."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "query")
+    device._connection.query.side_effect = [
+        {
+            "last_id": 3,
+            "sectors": {
+                0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": False, "name": "S1 Living Room"},
+                1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": False, "name": "S2 Bedroom"},
+                2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": False, "name": "S3 Outdoor"},
+            },
+        },
+        {
+            "last_id": 3,
+            "inputs": {
+                0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "Entryway Sensor"},
+                1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "Outdoor Sensor 1"},
+                2: {"id": 3, "index": 2, "element": 3, "excluded": True, "status": False, "name": "Outdoor Sensor 2"},
+            },
+        },
+    ]
+    # Test
+    device.update()
+    assert device.state == "disarmed"
+
+
+@pytest.mark.xfail
+def test_device_update_query_not_valid(client, mocker):
+    """Should not crash if an exception is raised."""
+    device = AlarmDevice(connection=client)
+    mocker.patch.object(device._connection, "query")
+    device._connection.query.side_effect = Exception("Unexpected")
+    # Test
+    assert device.update() is None
+
+
+def test_device_arm_success(client, mocker):
+    """Should arm the e-connect system using the underlying client."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "arm")
+    # Test
+    device._connection._session_id = "test"
+    device.arm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.arm.call_count == 1
+    assert "1234" in device._connection.lock.call_args[0]
+    assert {"sectors": [4]} == device._connection.arm.call_args[1]
+
+
+def test_device_arm_error(client, mocker):
+    """Should handle (log) connection errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "arm")
+    device._connection.lock.side_effect = HTTPError("Unable to communicate with e-Connect")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(HTTPError):
+        device.arm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.arm.call_count == 0
+
+
+def test_device_arm_lock_error(client, mocker):
+    """Should handle (log) locking errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "arm")
+    device._connection.lock.side_effect = LockError("Unable to acquire the lock")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(LockError):
+        device.arm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.arm.call_count == 0
+
+
+def test_device_arm_code_error(client, mocker):
+    """Should handle (log) code errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "arm")
+    device._connection.lock.side_effect = CodeError("Code is incorrect")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(CodeError):
+        device.arm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.arm.call_count == 0
+
+
+def test_device_disarm_success(client, mocker):
+    """Should disarm the e-connect system using the underlying client."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "disarm")
+    # Test
+    device._connection._session_id = "test"
+    device.disarm("1234", sectors=[4])
+
+    assert device._connection.lock.call_count == 1
+    assert device._connection.disarm.call_count == 1
+    assert "1234" in device._connection.lock.call_args[0]
+    assert {"sectors": [4]} == device._connection.disarm.call_args[1]
+
+
+def test_device_disarm_error(client, mocker):
+    """Should handle (log) connection errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "disarm")
+    device._connection.lock.side_effect = HTTPError("Unable to communicate with e-Connect")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(HTTPError):
+        device.disarm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.disarm.call_count == 0
+
+
+def test_device_disarm_lock_error(client, mocker):
+    """Should handle (log) locking errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "disarm")
+    device._connection.lock.side_effect = LockError("Unable to acquire the lock")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(LockError):
+        device.disarm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.disarm.call_count == 0
+
+
+def test_device_disarm_code_error(client, mocker):
+    """Should handle (log) code errors."""
+    device = AlarmDevice(connection=client)
+    mocker.spy(device._connection, "lock")
+    mocker.spy(device._connection, "disarm")
+    device._connection.lock.side_effect = CodeError("Code is incorrect")
+    device._connection._session_id = "test"
+    # Test
+    with pytest.raises(CodeError):
+        device.disarm("1234", sectors=[4])
+    assert device._connection.lock.call_count == 1
+    assert device._connection.disarm.call_count == 0


### PR DESCRIPTION
### Related Issues

- Closes #27 

### Proposed Changes:

Add `AlarmDevice` component to handle main unit states. This is a follow-up PR after it has been removed from `econnect-python` through PR (https://github.com/palazzem/econnect-python/pull/113)

### Testing:

`devices.py` is fully tested with a fake `client` that behaves like the original client. The client isn't a mock, only its responses are mocks.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
