### PR TITLE
fix(config): allow users to remove configuration for alarm modes

### DIFF
--- a/custom_components/econnect_alarm/helpers.py
+++ b/custom_components/econnect_alarm/helpers.py
@@ -34,6 +34,10 @@ def parse_areas_config(config: str, raises: bool = False):
         >>> parse_areas_config("3,a")
         []
     """
+    if config == "" or config is None:
+        # Empty config is considered valid (no sectors configured)
+        return []
+
     try:
         return [int(x) for x in config.split(",")]
     except (ValueError, AttributeError):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,11 @@ def test_parse_areas_config_valid_input():
     assert parse_areas_config("") == []
 
 
+def test_parse_areas_config_valid_empty_input():
+    assert parse_areas_config("", raises=True) == []
+    assert parse_areas_config(None, raises=True) == []
+
+
 def test_parse_areas_config_invalid_input():
     assert parse_areas_config("3,a") == []
     assert parse_areas_config("3.4") == []
@@ -22,11 +27,6 @@ def test_parse_areas_config_raises_value_error():
         parse_areas_config("3,a", raises=True)
     with pytest.raises(InvalidAreas):
         parse_areas_config("3.4", raises=True)
-
-
-def test_parse_areas_config_raises_attribute_error():
-    with pytest.raises(InvalidAreas):
-        parse_areas_config(None, raises=True)
 
 
 def test_parse_areas_config_whitespace():


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

When users configure an alarm mode (e.g. VACATION), now they can remove the configuration to disable this mode.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
