### PR TITLE
fix(build): build runner ships a `zip` package instead of a `tar.gz`

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Detect build version
         run: echo "PKG_VERSION=$(hatch version)" >> "$GITHUB_ENV"
 
-      - name: Build the package
+      - name: Build test package
         run: hatch -v build -t sdist
 
       - name: Log package content
@@ -46,9 +46,12 @@ jobs:
       - name: Test if the package is built correctly
         run: python -c "import custom_components.econnect_alarm"
 
+      - name: Build the release package
+        run: hatch -v build -t zipped-directory
+
       - name: Upload release archive
         uses: actions/upload-artifact@v3
         with:
-          name: econnect-alarm-${{ env.PKG_VERSION }}.tar.gz
-          path: dist/econnect_alarm-${{ env.PKG_VERSION }}.tar.gz
+          name: econnect-alarm-${{ env.PKG_VERSION }}.zip
+          path: dist/econnect_alarm-${{ env.PKG_VERSION }}.zip
           if-no-files-found: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling"]
+requires = [
+  "hatchling",
+  "hatch-zipped-directory",
+]
 build-backend = "hatchling.build"
 
 [project]
@@ -75,4 +78,7 @@ allow-direct-references = true
 asyncio_mode = "auto"
 
 [tool.hatch.build.targets.sdist]
+only-include = ["custom_components/econnect_alarm"]
+
+[tool.hatch.build.targets.zipped-directory]
 only-include = ["custom_components/econnect_alarm"]


### PR DESCRIPTION
### Related Issues

- Closes #37 

### Proposed Changes:

Extend `hatch` builder with `zipped-directory` plugin, so that the release runner can ship a ZIP package. To build a new package simply:
```
$ hatch -v build -t zipped-directory
```

`sdist` target is still needed to build a package that can be installed through `pip`.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
