### PR TITLE
refactor: use slugify function to generate the entity name as HA expects

### DIFF
--- a/custom_components/elmo_iess_alarm/helpers.py
+++ b/custom_components/elmo_iess_alarm/helpers.py
@@ -5,6 +5,7 @@ from elmo.api.client import ElmoClient
 from homeassistant import core
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import slugify
 
 from .const import CONF_DOMAIN, CONF_SYSTEM_NAME, CONF_SYSTEM_URL, DOMAIN
 from .exceptions import InvalidAreas
@@ -78,18 +79,23 @@ def generate_entity_name(entry: ConfigEntry, name: Union[str, None] = None) -> s
     Args:
         entry (ConfigEntry): The configuration entry from Home Assistant containing system
                              configuration or username.
+        name (Union[str, None]): Additional name component to be appended to the entity name.
 
     Returns:
         str: The generated entity name, which is a combination of the domain and either the configured
-             system name or the username.
+             system name or the username, optionally followed by the provided name.
 
     Example:
         >>> entry.data = {"system_name": "Seaside Home"}
         >>> generate_entity_name(entry, "window")
         "elmo_iess_alarm_seaside_home_window"
     """
-    if CONF_SYSTEM_NAME in entry.data:
-        entity_system_name = f"{DOMAIN} {entry.data[CONF_SYSTEM_NAME]} {name or ''}".strip()
-    else:
-        entity_system_name = f"{DOMAIN} {entry.data[CONF_USERNAME]} {name or ''}".strip()
-    return entity_system_name
+    # Retrieve the system name or username from the ConfigEntry
+    system_name = entry.data.get(CONF_SYSTEM_NAME) or entry.data.get(CONF_USERNAME)
+
+    # Default to empty string if a name is not provided
+    additional_name = name or ""
+
+    # Generate the entity name and use Home Assistant slugify to ensure it's a valid entity ID
+    entity_name = f"{DOMAIN}_{system_name}_{additional_name}"
+    return slugify(entity_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "homeassistant",
   "econnect-python==0.6.0",
+  "homeassistant",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -37,27 +37,32 @@ def test_parse_areas_config_whitespace():
 
 
 def test_generate_entity_name_empty(config_entry):
-    assert generate_entity_name(config_entry) == "elmo_iess_alarm test_user"
+    assert generate_entity_name(config_entry) == "elmo_iess_alarm_test_user"
 
 
 def test_generate_entity_name_with_name(config_entry):
-    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm test_user window"
+    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm_test_user_window"
 
 
 def test_generate_entity_name_with_none(config_entry):
-    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm test_user"
+    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_test_user"
 
 
 def test_generate_entity_name_empty_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry) == "elmo_iess_alarm Home"
+    assert generate_entity_name(config_entry) == "elmo_iess_alarm_home"
 
 
 def test_generate_entity_name_with_name_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm Home window"
+    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm_home_window"
 
 
 def test_generate_entity_name_with_none_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm Home"
+    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_home"
+
+
+def test_generate_entity_name_with_spaces(config_entry):
+    config_entry.data["system_name"] = "Home Assistant"
+    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_home_assistant"


### PR DESCRIPTION
### Related Issues

- Follow-up for PR #49 (cc @xtimmy86x )

### Proposed Changes:

Use HA public util `slugify()` to generate the entity name. The previous approach was working properly, even though it was relying on an internal mechanic where the entity name is normalized and then used as `entity_id`.

With this change we're explicit in how the format is.

### Testing:

Add testing to ensure we don't have `__` (as it happens in snake-case) when there is a space in the name.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
