### PR TITLE
feat!: binary sensors and control panels generates a valid Entity ID with a human readable name

### DIFF
--- a/custom_components/elmo_iess_alarm/alarm_control_panel.py
+++ b/custom_components/elmo_iess_alarm/alarm_control_panel.py
@@ -13,6 +13,7 @@ from homeassistant.components.alarm_control_panel.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    CONF_USERNAME,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
@@ -24,9 +25,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_DEVICE
+from .const import CONF_SYSTEM_NAME, DOMAIN, KEY_COORDINATOR, KEY_DEVICE
 from .decorators import set_device_state
-from .helpers import generate_entity_name
+from .helpers import generate_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,10 +40,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_d
     async_add_devices(
         [
             EconnectAlarm(
-                generate_entity_name(entry),
+                unique_id,
+                entry,
                 device,
                 coordinator,
-                unique_id,
             )
         ]
     )
@@ -51,12 +52,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_d
 class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
     """E-connect alarm entity."""
 
-    def __init__(self, name, device, coordinator, unique_id):
+    _attr_has_entity_name = True
+
+    def __init__(self, unique_id, config, device, coordinator):
         """Construct."""
         super().__init__(coordinator)
-        self._name = name
-        self._device = device
+        self.entity_id = generate_entity_id(config)
         self._unique_id = unique_id
+        self._name = f"Alarm Panel {config.data.get(CONF_SYSTEM_NAME) or config.data.get(CONF_USERNAME)}"
+        self._device = device
 
     @property
     def unique_id(self):

--- a/custom_components/elmo_iess_alarm/helpers.py
+++ b/custom_components/elmo_iess_alarm/helpers.py
@@ -97,5 +97,5 @@ def generate_entity_name(entry: ConfigEntry, name: Union[str, None] = None) -> s
     additional_name = name or ""
 
     # Generate the entity name and use Home Assistant slugify to ensure it's a valid entity ID
-    entity_name = f"{DOMAIN}_{system_name}_{additional_name}"
-    return slugify(entity_name)
+    entity_name = slugify(f"{system_name}_{additional_name}")
+    return f"{DOMAIN}.{entity_name}"

--- a/custom_components/elmo_iess_alarm/helpers.py
+++ b/custom_components/elmo_iess_alarm/helpers.py
@@ -73,29 +73,32 @@ async def validate_credentials(hass: core.HomeAssistant, config: dict):
     return True
 
 
-def generate_entity_name(entry: ConfigEntry, name: Union[str, None] = None) -> str:
-    """Generate a name for the entity based on system configuration or username.
+def generate_entity_id(config: ConfigEntry, name: Union[str, None] = None) -> str:
+    """Generate an entity ID based on system configuration or username.
 
     Args:
-        entry (ConfigEntry): The configuration entry from Home Assistant containing system
-                             configuration or username.
+        config (ConfigEntry): The configuration entry from Home Assistant containing system
+                              configuration or username.
         name (Union[str, None]): Additional name component to be appended to the entity name.
 
     Returns:
-        str: The generated entity name, which is a combination of the domain and either the configured
+        str: The generated entity id, which is a combination of the domain and either the configured
              system name or the username, optionally followed by the provided name.
 
     Example:
-        >>> entry.data = {"system_name": "Seaside Home"}
+        >>> config.data = {"system_name": "Seaside Home"}
         >>> generate_entity_name(entry, "window")
-        "elmo_iess_alarm_seaside_home_window"
+        "elmo_iess_alarm.seaside_home_window"
     """
     # Retrieve the system name or username from the ConfigEntry
-    system_name = entry.data.get(CONF_SYSTEM_NAME) or entry.data.get(CONF_USERNAME)
+    system_name = config.data.get(CONF_SYSTEM_NAME) or config.data.get(CONF_USERNAME)
 
     # Default to empty string if a name is not provided
     additional_name = name or ""
 
-    # Generate the entity name and use Home Assistant slugify to ensure it's a valid entity ID
+    # Generate the entity ID and use Home Assistant slugify to ensure it's a valid value
+    # NOTE: We append DOMAIN twice as HA removes the domain from the entity ID name. This is unexpected
+    # as it means we lose our namespacing, even though this is the suggested method explained in HA documentation.
+    # See: https://www.home-assistant.io/faq/unique_id/#can-be-changed
     entity_name = slugify(f"{system_name}_{additional_name}")
-    return f"{DOMAIN}.{entity_name}"
+    return f"{DOMAIN}.{DOMAIN}_{entity_name}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ async def hass(hass):
 
 
 @pytest.fixture(scope="function")
-def alarm_entity(hass, client):
+def alarm_entity(hass, client, config_entry):
     """Fixture to provide a test instance of the EconnectAlarm entity.
 
     This sets up an AlarmDevice and its corresponding DataUpdateCoordinator,
@@ -36,10 +36,8 @@ def alarm_entity(hass, client):
     """
     device = AlarmDevice(client)
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectAlarm(name="Test Alarm", device=device, coordinator=coordinator, unique_id="test_id")
-    # Set up the fixture
+    entity = EconnectAlarm(unique_id="test_id", config=config_entry, device=device, coordinator=coordinator)
     entity.hass = hass
-    entity.entity_id = "elmo_iess_alarm.test_id"
     yield entity
 
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -1,0 +1,40 @@
+import logging
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.elmo_iess_alarm.alarm_control_panel import EconnectAlarm
+from custom_components.elmo_iess_alarm.devices import AlarmDevice
+
+
+def test_alarm_panel_name(client, hass, config_entry):
+    # Ensure the Alarm Panel has the right name
+    device = AlarmDevice(client)
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlarm("test_id", config_entry, device, coordinator)
+    assert entity.name == "Alarm Panel test_user"
+
+
+def test_alarm_panel_name_with_system_name(client, hass, config_entry):
+    # Ensure the Entity ID takes into consideration the system optional name
+    config_entry.data["system_name"] = "Home"
+    device = AlarmDevice(client)
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlarm("test_id", config_entry, device, coordinator)
+    assert entity.name == "Alarm Panel Home"
+
+
+def test_alarm_panel_entity_id(client, hass, config_entry):
+    # Ensure the Alarm Panel has a valid Entity ID
+    device = AlarmDevice(client)
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlarm("test_id", config_entry, device, coordinator)
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user"
+
+
+def test_alarm_panel_entity_id_with_system_name(client, hass, config_entry):
+    # Ensure the Entity ID takes into consideration the system name
+    config_entry.data["system_name"] = "Home"
+    device = AlarmDevice(client)
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlarm("test_id", config_entry, device, coordinator)
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_home"

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -1,0 +1,43 @@
+import logging
+
+from elmo import query
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.elmo_iess_alarm.binary_sensor import EconnectDoorWindowSensor
+
+
+def test_binary_sensor_door_window_name(hass, config_entry, alarm_entity):
+    # Ensure the Alarm Panel has the right name
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectDoorWindowSensor(
+        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
+    )
+    assert entity.name == "1 Tamper Sirena"
+
+
+def test_binary_sensor_door_window_name_with_system_name(hass, config_entry, alarm_entity):
+    # The system name doesn't change the Entity name
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectDoorWindowSensor(
+        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
+    )
+    assert entity.name == "1 Tamper Sirena"
+
+
+def test_binary_sensor_door_window_entity_id(hass, config_entry, alarm_entity):
+    # Ensure the Alarm Panel has a valid Entity ID
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectDoorWindowSensor(
+        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
+    )
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user_1_tamper_sirena"
+
+
+def test_binary_sensor_door_window_entity_id_with_system_name(hass, config_entry, alarm_entity):
+    # Ensure the Entity ID takes into consideration the system name
+    config_entry.data["system_name"] = "Home"
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectDoorWindowSensor(
+        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
+    )
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_home_1_tamper_sirena"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from homeassistant.core import valid_entity_id
 
 from custom_components.elmo_iess_alarm.exceptions import InvalidAreas
 from custom_components.elmo_iess_alarm.helpers import (
-    generate_entity_name,
+    generate_entity_id,
     parse_areas_config,
 )
 
@@ -38,46 +38,46 @@ def test_parse_areas_config_whitespace():
 
 
 def test_generate_entity_name_empty(config_entry):
-    entity_id = generate_entity_name(config_entry)
-    assert entity_id == "elmo_iess_alarm.test_user"
+    entity_id = generate_entity_id(config_entry)
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_name(config_entry):
-    entity_id = generate_entity_name(config_entry, "window")
-    assert entity_id == "elmo_iess_alarm.test_user_window"
+    entity_id = generate_entity_id(config_entry, "window")
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user_window"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_none(config_entry):
-    entity_id = generate_entity_name(config_entry, None)
-    assert entity_id == "elmo_iess_alarm.test_user"
+    entity_id = generate_entity_id(config_entry, None)
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_empty_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    entity_id = generate_entity_name(config_entry)
-    assert entity_id == "elmo_iess_alarm.home"
+    entity_id = generate_entity_id(config_entry)
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_home"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_name_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    entity_id = generate_entity_name(config_entry, "window")
-    assert entity_id == "elmo_iess_alarm.home_window"
+    entity_id = generate_entity_id(config_entry, "window")
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_home_window"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_none_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    entity_id = generate_entity_name(config_entry, None)
-    assert entity_id == "elmo_iess_alarm.home"
+    entity_id = generate_entity_id(config_entry, None)
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_home"
     assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_spaces(config_entry):
     config_entry.data["system_name"] = "Home Assistant"
-    entity_id = generate_entity_name(config_entry)
-    assert entity_id == "elmo_iess_alarm.home_assistant"
+    entity_id = generate_entity_id(config_entry)
+    assert entity_id == "elmo_iess_alarm.elmo_iess_alarm_home_assistant"
     assert valid_entity_id(entity_id)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+from homeassistant.core import valid_entity_id
 
 from custom_components.elmo_iess_alarm.exceptions import InvalidAreas
 from custom_components.elmo_iess_alarm.helpers import (
@@ -37,32 +38,46 @@ def test_parse_areas_config_whitespace():
 
 
 def test_generate_entity_name_empty(config_entry):
-    assert generate_entity_name(config_entry) == "elmo_iess_alarm_test_user"
+    entity_id = generate_entity_name(config_entry)
+    assert entity_id == "elmo_iess_alarm.test_user"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_name(config_entry):
-    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm_test_user_window"
+    entity_id = generate_entity_name(config_entry, "window")
+    assert entity_id == "elmo_iess_alarm.test_user_window"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_none(config_entry):
-    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_test_user"
+    entity_id = generate_entity_name(config_entry, None)
+    assert entity_id == "elmo_iess_alarm.test_user"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_empty_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry) == "elmo_iess_alarm_home"
+    entity_id = generate_entity_name(config_entry)
+    assert entity_id == "elmo_iess_alarm.home"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_name_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry, "window") == "elmo_iess_alarm_home_window"
+    entity_id = generate_entity_name(config_entry, "window")
+    assert entity_id == "elmo_iess_alarm.home_window"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_none_system(config_entry):
     config_entry.data["system_name"] = "Home"
-    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_home"
+    entity_id = generate_entity_name(config_entry, None)
+    assert entity_id == "elmo_iess_alarm.home"
+    assert valid_entity_id(entity_id)
 
 
 def test_generate_entity_name_with_spaces(config_entry):
     config_entry.data["system_name"] = "Home Assistant"
-    assert generate_entity_name(config_entry, None) == "elmo_iess_alarm_home_assistant"
+    entity_id = generate_entity_name(config_entry)
+    assert entity_id == "elmo_iess_alarm.home_assistant"
+    assert valid_entity_id(entity_id)


### PR DESCRIPTION
### Related Issues

- #53 

### Proposed Changes:

This change ensures that the self-generated `entity_id` is a valid HA Entity ID, while keeping the name in a human readable format. The validation is done via tests using `valid_entity_id()` HA core function and is not validated at runtime (there is no reasons to do that live).

Even if the integration was working properly, entities were not respecting the official `entity_id` format: `<domain>.<entity_id>`. With this change, `domain` is included in the Entity ID even though it is remove by HA for unclear reasons. This behavior is described in the official documentation: https://www.home-assistant.io/faq/unique_id/#can-be-changed

#### Example

Before:
<img width="876" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/0c9e5c9c-267e-4c0c-baf8-a0060abc10cd">


After:
<img width="846" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/61229289-ed8b-42be-9b11-2475c931605c">


### Testing:

Install the integration before the change and after the change. If `name` is not set with a "friendly name", you should see this change.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
