### PR TITLE
feat: add system global states to monitor the central unit

### DIFF
--- a/custom_components/elmo_iess_alarm/binary_sensor.py
+++ b/custom_components/elmo_iess_alarm/binary_sensor.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class EconnectAlertSensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a e-Connect alerts."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         unique_id: str,
@@ -72,9 +74,8 @@ class EconnectAlertSensor(CoordinatorEntity, BinarySensorEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
-        """Return the name of this entity."""
-        # TODO: this needs to be translated with a friendly name
+    def translation_key(self) -> str:
+        """Return the translation key to translate the entity's name and states."""
         return self._alert_id
 
     @property

--- a/custom_components/elmo_iess_alarm/devices.py
+++ b/custom_components/elmo_iess_alarm/devices.py
@@ -53,6 +53,7 @@ class AlarmDevice:
 
         # Alarm state
         self.state = STATE_UNAVAILABLE
+        self.alerts = {}
         self.sectors_armed = {}
         self.sectors_disarmed = {}
         self.inputs_alerted = {}
@@ -148,6 +149,7 @@ class AlarmDevice:
         try:
             sectors = self._connection.query(q.SECTORS)
             inputs = self._connection.query(q.INPUTS)
+            alerts = self._connection.get_status()
         except (HTTPError, ParseError) as err:
             _LOGGER.error(f"Device | Error while checking if there are updates: {err}")
             raise
@@ -160,6 +162,9 @@ class AlarmDevice:
 
         self._lastIds[q.SECTORS] = sectors.get("last_id", 0)
         self._lastIds[q.INPUTS] = inputs.get("last_id", 0)
+
+        # Update system alerts
+        self.alerts = alerts
 
         # Update the internal state machine (mapping state)
         self.state = self.get_state()

--- a/custom_components/elmo_iess_alarm/manifest.json
+++ b/custom_components/elmo_iess_alarm/manifest.json
@@ -15,7 +15,7 @@
     "custom_components.elmo_iess_alarm"
   ],
   "requirements": [
-    "econnect-python==0.6.0"
+    "econnect-python==0.7.0"
   ],
   "version": "1.0.0"
 }

--- a/custom_components/elmo_iess_alarm/strings.json
+++ b/custom_components/elmo_iess_alarm/strings.json
@@ -23,21 +23,200 @@
     }
   },
   "options": {
-      "error": {
-          "invalid_areas": "Selected sectors are invalid",
-          "unknown": "Unexpected error: check your logs"
-      },
-      "step": {
-          "init": {
-            "data": {
-              "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
-              "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-              "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
-              "scan_interval": "Scan interval (e.g. 120 - optional)"
-            },
-            "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
-            "title": "Configure your Elmo/IESS system"
-          }
+    "error": {
+      "invalid_areas": "Selected sectors are invalid",
+      "unknown": "Unexpected error: check your logs"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
+          "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
+          "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+          "scan_interval": "Scan interval (e.g. 120 - optional)"
+        },
+        "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
+        "title": "Configure your Elmo/IESS system"
       }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "anomalies_led": {
+        "name": "Anomalies LED",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "inputs_led": {
+        "name": "Inputs LED",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "alarm_led": {
+        "name": "Alarm LED",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "tamper_led": {
+        "name": "Tamper LED",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
+      "has_anomaly": {
+        "name": "Anomalies",
+        "state": {
+          "on": "Detected",
+          "off": "No"
+        }
+      },
+      "panel_tamper": {
+        "name": "System Protection",
+        "state": {
+          "on": "Tampered",
+          "off": "Secure"
+        }
+      },
+      "panel_no_power": {
+        "name": "System Power",
+        "state": {
+          "on": "No Power",
+          "off": "Powered"
+        }
+      },
+      "panel_low_battery": {
+        "name": "System Battery",
+        "state": {
+          "on": "Low Battery",
+          "off": "OK"
+        }
+      },
+      "gsm_anomaly": {
+        "name": "GSM Status",
+        "state": {
+          "on": "Anomaly",
+          "off": "OK"
+        }
+      },
+      "gsm_low_balance": {
+        "name": "GSM Plafond Balance",
+        "state": {
+          "on": "Low",
+          "off": "OK"
+        }
+      },
+      "pstn_anomaly": {
+        "name": "PSTN Anomaly",
+        "state": {
+          "on": "Detected",
+          "off": "No"
+        }
+      },
+      "system_test": {
+        "name": "System Test",
+        "state": {
+          "on": "Required",
+          "off": "OK"
+        }
+      },
+      "module_registration": {
+        "name": "Module Registration",
+        "state": {
+          "on": "Registering",
+          "off": "Not Registering"
+        }
+      },
+      "rf_interference": {
+        "name": "RF Interference",
+        "state": {
+          "on": "Detected",
+          "off": "No"
+        }
+      },
+      "input_failure": {
+        "name": "Input Failure",
+        "state": {
+          "on": "Detected",
+          "off": "No"
+        }
+      },
+      "input_alarm": {
+        "name": "Input Alarm",
+        "state": {
+          "on": "Triggered",
+          "off": "No"
+        }
+      },
+      "input_bypass": {
+        "name": "Input Bypass",
+        "state": {
+          "on": "Bypassed",
+          "off": "No"
+        }
+      },
+      "input_low_battery": {
+        "name": "Input Battery",
+        "state": {
+          "on": "Low Battery",
+          "off": "OK"
+        }
+      },
+      "input_no_supervision": {
+        "name": "Input No Supervision",
+        "state": {
+          "on": "Not Supervised",
+          "off": "Supervised"
+        }
+      },
+      "device_tamper": {
+        "name": "Device Protection",
+        "state": {
+          "on": "Tampered",
+          "off": "Secure"
+        }
+      },
+      "device_failure": {
+        "name": "Device Failure",
+        "state": {
+          "on": "Detected",
+          "off": "No"
+        }
+      },
+      "device_no_power": {
+        "name": "Device Power",
+        "state": {
+          "on": "No Power",
+          "off": "Powered"
+        }
+      },
+      "device_low_battery": {
+        "name": "Device Battery",
+        "state": {
+          "on": "Low Battery",
+          "off": "OK"
+        }
+      },
+      "device_no_supervision": {
+        "name": "Device No Supervision",
+        "state": {
+          "on": "Not Supervised",
+          "off": "Supervised"
+        }
+      },
+      "device_system_block": {
+        "name": "Device System Block",
+        "state": {
+          "on": "Blocked",
+          "off": "Not Blocked"
+        }
+      }
+    }
   }
 }

--- a/custom_components/elmo_iess_alarm/strings.json
+++ b/custom_components/elmo_iess_alarm/strings.json
@@ -1,222 +1,222 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "domain": "Domain name (optional)",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "system_name": "[%key:common::config_flow::data::system_name%]"
+    "config": {
+        "step": {
+            "user": {
+                "data": {
+                    "domain": "Domain name (optional)",
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "system_name": "[%key:common::config_flow::data::system_name%]"
+                },
+                "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
+                "title": "Configure your Elmo/IESS system"
+            }
         },
-        "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
-        "title": "Configure your Elmo/IESS system"
-      }
-    },
-    "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_areas": "Digited areas (home or night) are invalid",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    }
-  },
-  "options": {
-    "error": {
-      "invalid_areas": "Selected sectors are invalid",
-      "unknown": "Unexpected error: check your logs"
-    },
-    "step": {
-      "init": {
-        "data": {
-          "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
-          "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-          "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
-          "scan_interval": "Scan interval (e.g. 120 - optional)"
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "invalid_areas": "Digited areas (home or night) are invalid",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
         },
-        "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
-        "title": "Configure your Elmo/IESS system"
-      }
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+        }
+    },
+    "options": {
+        "error": {
+            "invalid_areas": "Selected sectors are invalid",
+            "unknown": "Unexpected error: check your logs"
+        },
+        "step": {
+            "init": {
+                "data": {
+                    "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
+                    "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
+                    "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+                    "scan_interval": "Scan interval (e.g. 120 - optional)"
+                },
+                "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
+                "title": "Configure your Elmo/IESS system"
+            }
+        }
+    },
+    "entity": {
+        "binary_sensor": {
+            "anomalies_led": {
+                "name": "General Anomaly",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "inputs_led": {
+                "name": "Zones Ready Status",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "alarm_led": {
+                "name": "General Alarm",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "tamper_led": {
+                "name": "General Tamper",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "has_anomaly": {
+                "name": "Anomalies",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "panel_tamper": {
+                "name": "Panel Tamper",
+                "state": {
+                    "on": "Tampered",
+                    "off": "Secure"
+                }
+            },
+            "panel_no_power": {
+                "name": "System Main Power",
+                "state": {
+                    "on": "No Power",
+                    "off": "Powered"
+                }
+            },
+            "panel_low_battery": {
+                "name": "System Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "gsm_anomaly": {
+                "name": "GSM Status",
+                "state": {
+                    "on": "Anomaly",
+                    "off": "OK"
+                }
+            },
+            "gsm_low_balance": {
+                "name": "GSM Plafond Balance",
+                "state": {
+                    "on": "Low",
+                    "off": "OK"
+                }
+            },
+            "pstn_anomaly": {
+                "name": "PSTN Anomaly",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "system_test": {
+                "name": "System Test",
+                "state": {
+                    "on": "Required",
+                    "off": "OK"
+                }
+            },
+            "module_registration": {
+                "name": "Module Registration",
+                "state": {
+                    "on": "Registering",
+                    "off": "Not Registering"
+                }
+            },
+            "rf_interference": {
+                "name": "RF Interference",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "input_failure": {
+                "name": "Input Failure",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "input_alarm": {
+                "name": "Input Alarm",
+                "state": {
+                    "on": "Triggered",
+                    "off": "No"
+                }
+            },
+            "input_bypass": {
+                "name": "Input Bypass",
+                "state": {
+                    "on": "Bypassed",
+                    "off": "No"
+                }
+            },
+            "input_low_battery": {
+                "name": "Input Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "input_no_supervision": {
+                "name": "Input No Supervision",
+                "state": {
+                    "on": "Not Supervised",
+                    "off": "Supervised"
+                }
+            },
+            "device_tamper": {
+                "name": "Device Protection",
+                "state": {
+                    "on": "Tampered",
+                    "off": "Secure"
+                }
+            },
+            "device_failure": {
+                "name": "Device Failure",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "device_no_power": {
+                "name": "Device Power",
+                "state": {
+                    "on": "No Power",
+                    "off": "Powered"
+                }
+            },
+            "device_low_battery": {
+                "name": "Device Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "device_no_supervision": {
+                "name": "Device No Supervision",
+                "state": {
+                    "on": "Not Supervised",
+                    "off": "Supervised"
+                }
+            },
+            "device_system_block": {
+                "name": "Device System Block",
+                "state": {
+                    "on": "Blocked",
+                    "off": "Not Blocked"
+                }
+            }
+        }
     }
-  },
-  "entity": {
-    "binary_sensor": {
-      "anomalies_led": {
-        "name": "Anomalies LED",
-        "state": {
-          "on": "On",
-          "off": "Off"
-        }
-      },
-      "inputs_led": {
-        "name": "Inputs LED",
-        "state": {
-          "on": "On",
-          "off": "Off"
-        }
-      },
-      "alarm_led": {
-        "name": "Alarm LED",
-        "state": {
-          "on": "On",
-          "off": "Off"
-        }
-      },
-      "tamper_led": {
-        "name": "Tamper LED",
-        "state": {
-          "on": "On",
-          "off": "Off"
-        }
-      },
-      "has_anomaly": {
-        "name": "Anomalies",
-        "state": {
-          "on": "Detected",
-          "off": "No"
-        }
-      },
-      "panel_tamper": {
-        "name": "System Protection",
-        "state": {
-          "on": "Tampered",
-          "off": "Secure"
-        }
-      },
-      "panel_no_power": {
-        "name": "System Power",
-        "state": {
-          "on": "No Power",
-          "off": "Powered"
-        }
-      },
-      "panel_low_battery": {
-        "name": "System Battery",
-        "state": {
-          "on": "Low Battery",
-          "off": "OK"
-        }
-      },
-      "gsm_anomaly": {
-        "name": "GSM Status",
-        "state": {
-          "on": "Anomaly",
-          "off": "OK"
-        }
-      },
-      "gsm_low_balance": {
-        "name": "GSM Plafond Balance",
-        "state": {
-          "on": "Low",
-          "off": "OK"
-        }
-      },
-      "pstn_anomaly": {
-        "name": "PSTN Anomaly",
-        "state": {
-          "on": "Detected",
-          "off": "No"
-        }
-      },
-      "system_test": {
-        "name": "System Test",
-        "state": {
-          "on": "Required",
-          "off": "OK"
-        }
-      },
-      "module_registration": {
-        "name": "Module Registration",
-        "state": {
-          "on": "Registering",
-          "off": "Not Registering"
-        }
-      },
-      "rf_interference": {
-        "name": "RF Interference",
-        "state": {
-          "on": "Detected",
-          "off": "No"
-        }
-      },
-      "input_failure": {
-        "name": "Input Failure",
-        "state": {
-          "on": "Detected",
-          "off": "No"
-        }
-      },
-      "input_alarm": {
-        "name": "Input Alarm",
-        "state": {
-          "on": "Triggered",
-          "off": "No"
-        }
-      },
-      "input_bypass": {
-        "name": "Input Bypass",
-        "state": {
-          "on": "Bypassed",
-          "off": "No"
-        }
-      },
-      "input_low_battery": {
-        "name": "Input Battery",
-        "state": {
-          "on": "Low Battery",
-          "off": "OK"
-        }
-      },
-      "input_no_supervision": {
-        "name": "Input No Supervision",
-        "state": {
-          "on": "Not Supervised",
-          "off": "Supervised"
-        }
-      },
-      "device_tamper": {
-        "name": "Device Protection",
-        "state": {
-          "on": "Tampered",
-          "off": "Secure"
-        }
-      },
-      "device_failure": {
-        "name": "Device Failure",
-        "state": {
-          "on": "Detected",
-          "off": "No"
-        }
-      },
-      "device_no_power": {
-        "name": "Device Power",
-        "state": {
-          "on": "No Power",
-          "off": "Powered"
-        }
-      },
-      "device_low_battery": {
-        "name": "Device Battery",
-        "state": {
-          "on": "Low Battery",
-          "off": "OK"
-        }
-      },
-      "device_no_supervision": {
-        "name": "Device No Supervision",
-        "state": {
-          "on": "Not Supervised",
-          "off": "Supervised"
-        }
-      },
-      "device_system_block": {
-        "name": "Device System Block",
-        "state": {
-          "on": "Blocked",
-          "off": "Not Blocked"
-        }
-      }
-    }
-  }
 }

--- a/custom_components/elmo_iess_alarm/translations/en.json
+++ b/custom_components/elmo_iess_alarm/translations/en.json
@@ -43,28 +43,28 @@
     "entity": {
         "binary_sensor": {
             "anomalies_led": {
-                "name": "Anomalies LED",
+                "name": "General Anomaly",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "inputs_led": {
-                "name": "Inputs LED",
+                "name": "Zones Ready Status",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "alarm_led": {
-                "name": "Alarm LED",
+                "name": "General Alarm",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "tamper_led": {
-                "name": "Tamper LED",
+                "name": "General Tamper",
                 "state": {
                     "on": "On",
                     "off": "Off"
@@ -78,14 +78,14 @@
                 }
             },
             "panel_tamper": {
-                "name": "System Protection",
+                "name": "Panel Tamper",
                 "state": {
                     "on": "Tampered",
                     "off": "Secure"
                 }
             },
             "panel_no_power": {
-                "name": "System Power",
+                "name": "System Main Power",
                 "state": {
                     "on": "No Power",
                     "off": "Powered"

--- a/custom_components/elmo_iess_alarm/translations/en.json
+++ b/custom_components/elmo_iess_alarm/translations/en.json
@@ -39,5 +39,184 @@
                 "title": "Configure your Elmo/IESS system"
             }
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "anomalies_led": {
+                "name": "Anomalies LED",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "inputs_led": {
+                "name": "Inputs LED",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "alarm_led": {
+                "name": "Alarm LED",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "tamper_led": {
+                "name": "Tamper LED",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "has_anomaly": {
+                "name": "Anomalies",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "panel_tamper": {
+                "name": "System Protection",
+                "state": {
+                    "on": "Tampered",
+                    "off": "Secure"
+                }
+            },
+            "panel_no_power": {
+                "name": "System Power",
+                "state": {
+                    "on": "No Power",
+                    "off": "Powered"
+                }
+            },
+            "panel_low_battery": {
+                "name": "System Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "gsm_anomaly": {
+                "name": "GSM Status",
+                "state": {
+                    "on": "Anomaly",
+                    "off": "OK"
+                }
+            },
+            "gsm_low_balance": {
+                "name": "GSM Plafond Balance",
+                "state": {
+                    "on": "Low",
+                    "off": "OK"
+                }
+            },
+            "pstn_anomaly": {
+                "name": "PSTN Anomaly",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "system_test": {
+                "name": "System Test",
+                "state": {
+                    "on": "Required",
+                    "off": "OK"
+                }
+            },
+            "module_registration": {
+                "name": "Module Registration",
+                "state": {
+                    "on": "Registering",
+                    "off": "Not Registering"
+                }
+            },
+            "rf_interference": {
+                "name": "RF Interference",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "input_failure": {
+                "name": "Input Failure",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "input_alarm": {
+                "name": "Input Alarm",
+                "state": {
+                    "on": "Triggered",
+                    "off": "No"
+                }
+            },
+            "input_bypass": {
+                "name": "Input Bypass",
+                "state": {
+                    "on": "Bypassed",
+                    "off": "No"
+                }
+            },
+            "input_low_battery": {
+                "name": "Input Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "input_no_supervision": {
+                "name": "Input No Supervision",
+                "state": {
+                    "on": "Not Supervised",
+                    "off": "Supervised"
+                }
+            },
+            "device_tamper": {
+                "name": "Device Protection",
+                "state": {
+                    "on": "Tampered",
+                    "off": "Secure"
+                }
+            },
+            "device_failure": {
+                "name": "Device Failure",
+                "state": {
+                    "on": "Detected",
+                    "off": "No"
+                }
+            },
+            "device_no_power": {
+                "name": "Device Power",
+                "state": {
+                    "on": "No Power",
+                    "off": "Powered"
+                }
+            },
+            "device_low_battery": {
+                "name": "Device Battery",
+                "state": {
+                    "on": "Low Battery",
+                    "off": "OK"
+                }
+            },
+            "device_no_supervision": {
+                "name": "Device No Supervision",
+                "state": {
+                    "on": "Not Supervised",
+                    "off": "Supervised"
+                }
+            },
+            "device_system_block": {
+                "name": "Device System Block",
+                "state": {
+                    "on": "Blocked",
+                    "off": "Not Blocked"
+                }
+            }
+        }
     }
 }

--- a/custom_components/elmo_iess_alarm/translations/it.json
+++ b/custom_components/elmo_iess_alarm/translations/it.json
@@ -43,28 +43,28 @@
     "entity": {
         "binary_sensor": {
             "anomalies_led": {
-                "name": "LED Anomalie",
+                "name": "Anomalia Generale",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "inputs_led": {
-                "name": "LED Ingressi",
+                "name": "Stato Inseribilità Zone",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "alarm_led": {
-                "name": "LED Allarme",
+                "name": "Allarme Generale",
                 "state": {
                     "on": "On",
                     "off": "Off"
                 }
             },
             "tamper_led": {
-                "name": "LED Manomissione",
+                "name": "Manomissione Generale",
                 "state": {
                     "on": "On",
                     "off": "Off"
@@ -78,7 +78,7 @@
                 }
             },
             "panel_tamper": {
-                "name": "Protezione Sistema",
+                "name": "Manomissione Centrale",
                 "state": {
                     "on": "Manomesso",
                     "off": "Sicuro"
@@ -120,7 +120,7 @@
                 }
             },
             "system_test": {
-                "name": "Test Sistema",
+                "name": "Test Impianto",
                 "state": {
                     "on": "Richiesto",
                     "off": "OK"
@@ -169,14 +169,14 @@
                 }
             },
             "input_no_supervision": {
-                "name": "Ingresso Non Supervisionato",
+                "name": "Mancata Supervisione Ingresso",
                 "state": {
                     "on": "Non Supervisionato",
                     "off": "Supervisionato"
                 }
             },
             "device_tamper": {
-                "name": "Protezione Dispositivo",
+                "name": "Manomissione Dispositivo",
                 "state": {
                     "on": "Manomesso",
                     "off": "Sicuro"
@@ -204,7 +204,7 @@
                 }
             },
             "device_no_supervision": {
-                "name": "Dispositivo Non Supervisionato",
+                "name": "Mancata Supervisione Dispositivo",
                 "state": {
                     "on": "Non Supervisionato",
                     "off": "Supervisionato"

--- a/custom_components/elmo_iess_alarm/translations/it.json
+++ b/custom_components/elmo_iess_alarm/translations/it.json
@@ -39,5 +39,184 @@
                 "title": "Configura il tuo sistema Elmo/IESS"
             }
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "anomalies_led": {
+                "name": "LED Anomalie",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "inputs_led": {
+                "name": "LED Ingressi",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "alarm_led": {
+                "name": "LED Allarme",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "tamper_led": {
+                "name": "LED Manomissione",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            },
+            "has_anomaly": {
+                "name": "Anomalia",
+                "state": {
+                    "on": "Rilevata",
+                    "off": "No"
+                }
+            },
+            "panel_tamper": {
+                "name": "Protezione Sistema",
+                "state": {
+                    "on": "Manomesso",
+                    "off": "Sicuro"
+                }
+            },
+            "panel_no_power": {
+                "name": "Alimentazione Sistema",
+                "state": {
+                    "on": "Senza Alimentazione",
+                    "off": "Alimentato"
+                }
+            },
+            "panel_low_battery": {
+                "name": "Batteria Sistema",
+                "state": {
+                    "on": "Batteria Scarica",
+                    "off": "OK"
+                }
+            },
+            "gsm_anomaly": {
+                "name": "Stato GSM",
+                "state": {
+                    "on": "Anomalia",
+                    "off": "OK"
+                }
+            },
+            "gsm_low_balance": {
+                "name": "Credito GSM",
+                "state": {
+                    "on": "Scarso",
+                    "off": "OK"
+                }
+            },
+            "pstn_anomaly": {
+                "name": "Anomalia PSTN",
+                "state": {
+                    "on": "Rilevato",
+                    "off": "No"
+                }
+            },
+            "system_test": {
+                "name": "Test Sistema",
+                "state": {
+                    "on": "Richiesto",
+                    "off": "OK"
+                }
+            },
+            "module_registration": {
+                "name": "Registrazione Modulo",
+                "state": {
+                    "on": "In Registrazione",
+                    "off": "Non in Registrazione"
+                }
+            },
+            "rf_interference": {
+                "name": "Interferenza RF",
+                "state": {
+                    "on": "Rilevato",
+                    "off": "No"
+                }
+            },
+            "input_failure": {
+                "name": "Guasto Ingresso",
+                "state": {
+                    "on": "Rilevato",
+                    "off": "No"
+                }
+            },
+            "input_alarm": {
+                "name": "Allarme Ingresso",
+                "state": {
+                    "on": "Innesca",
+                    "off": "No"
+                }
+            },
+            "input_bypass": {
+                "name": "Bypass Ingresso",
+                "state": {
+                    "on": "Bypassato",
+                    "off": "No"
+                }
+            },
+            "input_low_battery": {
+                "name": "Batteria Ingresso",
+                "state": {
+                    "on": "Batteria Scarica",
+                    "off": "OK"
+                }
+            },
+            "input_no_supervision": {
+                "name": "Ingresso Non Supervisionato",
+                "state": {
+                    "on": "Non Supervisionato",
+                    "off": "Supervisionato"
+                }
+            },
+            "device_tamper": {
+                "name": "Protezione Dispositivo",
+                "state": {
+                    "on": "Manomesso",
+                    "off": "Sicuro"
+                }
+            },
+            "device_failure": {
+                "name": "Guasto Dispositivo",
+                "state": {
+                    "on": "Rilevato",
+                    "off": "No"
+                }
+            },
+            "device_no_power": {
+                "name": "Alimentazione Dispositivo",
+                "state": {
+                    "on": "Senza Alimentazione",
+                    "off": "Alimentato"
+                }
+            },
+            "device_low_battery": {
+                "name": "Batteria Dispositivo",
+                "state": {
+                    "on": "Batteria Scarica",
+                    "off": "OK"
+                }
+            },
+            "device_no_supervision": {
+                "name": "Dispositivo Non Supervisionato",
+                "state": {
+                    "on": "Non Supervisionato",
+                    "off": "Supervisionato"
+                }
+            },
+            "device_system_block": {
+                "name": "Blocco Sistema Dispositivo",
+                "state": {
+                    "on": "Bloccato",
+                    "off": "Non Bloccato"
+                }
+            }
+        }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.6.0",
+  "econnect-python==0.7.0",
   "homeassistant",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def client():
         server.add(responses.POST, "https://example.com/api/strings", body=r.STRINGS, status=200)
         server.add(responses.POST, "https://example.com/api/areas", body=r.AREAS, status=200)
         server.add(responses.POST, "https://example.com/api/inputs", body=r.INPUTS, status=200)
+        server.add(responses.POST, "https://example.com/api/statusadv", body=r.STATUS, status=200)
         yield client
 
 

--- a/tests/fixtures/responses.py
+++ b/tests/fixtures/responses.py
@@ -240,3 +240,43 @@ INPUTS = """[
        "InProgress": false
    }
 ]"""
+STATUS = """
+    {
+        "StatusUid": 1,
+        "PanelLeds": {
+            "InputsLed": 2,
+            "AnomaliesLed": 1,
+            "AlarmLed": 0,
+            "TamperLed": 0
+        },
+        "PanelAnomalies": {
+            "HasAnomaly": false,
+            "PanelTamper": 0,
+            "PanelNoPower": 0,
+            "PanelLowBattery": 0,
+            "GsmAnomaly": 0,
+            "GsmLowBalance": 0,
+            "PstnAnomaly": 0,
+            "SystemTest": 0,
+            "ModuleRegistration": 0,
+            "RfInterference": 0,
+            "InputFailure": 0,
+            "InputAlarm": 0,
+            "InputBypass": 0,
+            "InputLowBattery": 0,
+            "InputNoSupervision": 0,
+            "DeviceTamper": 0,
+            "DeviceFailure": 0,
+            "DeviceNoPower": 0,
+            "DeviceLowBattery": 0,
+            "DeviceNoSupervision": 0,
+            "DeviceSystemBlock": 0
+        },
+        "PanelAlignmentAdv": {
+            "ManualFwUpAvailable": false,
+            "Id": 1,
+            "Index": -1,
+            "Element": 0
+        }
+    }
+"""

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -47,17 +47,17 @@ def test_binary_sensor_door_window_entity_id_with_system_name(hass, config_entry
 
 
 def test_binary_sensor_alert_name(hass, config_entry, alarm_entity):
-    # Ensure the alert has the right name
+    # Ensure the alert has the right translation key
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
     entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.name == "has_anomalies"
+    assert entity.translation_key == "has_anomalies"
 
 
 def test_binary_sensor_alert_name_with_system_name(hass, config_entry, alarm_entity):
-    # The system name doesn't change the Entity name
+    # The system name doesn't change the translation key
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
     entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.name == "has_anomalies"
+    assert entity.translation_key == "has_anomalies"
 
 
 def test_binary_sensor_alert_entity_id(hass, config_entry, alarm_entity):

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -3,11 +3,14 @@ import logging
 from elmo import query
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from custom_components.elmo_iess_alarm.binary_sensor import EconnectDoorWindowSensor
+from custom_components.elmo_iess_alarm.binary_sensor import (
+    EconnectAlertSensor,
+    EconnectDoorWindowSensor,
+)
 
 
 def test_binary_sensor_door_window_name(hass, config_entry, alarm_entity):
-    # Ensure the Alarm Panel has the right name
+    # Ensure the sensor has the right name
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
     entity = EconnectDoorWindowSensor(
         "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
@@ -25,7 +28,7 @@ def test_binary_sensor_door_window_name_with_system_name(hass, config_entry, ala
 
 
 def test_binary_sensor_door_window_entity_id(hass, config_entry, alarm_entity):
-    # Ensure the Alarm Panel has a valid Entity ID
+    # Ensure the sensor has a valid Entity ID
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
     entity = EconnectDoorWindowSensor(
         "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
@@ -41,3 +44,32 @@ def test_binary_sensor_door_window_entity_id_with_system_name(hass, config_entry
         "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
     )
     assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_home_1_tamper_sirena"
+
+
+def test_binary_sensor_alert_name(hass, config_entry, alarm_entity):
+    # Ensure the alert has the right name
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+    assert entity.name == "has_anomalies"
+
+
+def test_binary_sensor_alert_name_with_system_name(hass, config_entry, alarm_entity):
+    # The system name doesn't change the Entity name
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+    assert entity.name == "has_anomalies"
+
+
+def test_binary_sensor_alert_entity_id(hass, config_entry, alarm_entity):
+    # Ensure the alert has a valid Entity ID
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_test_user_has_anomalies"
+
+
+def test_binary_sensor_alert_entity_id_with_system_name(hass, config_entry, alarm_entity):
+    # Ensure the Entity ID takes into consideration the system name
+    config_entry.data["system_name"] = "Home"
+    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
+    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+    assert entity.entity_id == "elmo_iess_alarm.elmo_iess_alarm_home_has_anomalies"

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -195,6 +195,7 @@ def test_device_update_state_machine_armed(client, mocker):
     """Should check if the state machine is properly updated after calling update()."""
     device = AlarmDevice(client)
     mocker.patch.object(device._connection, "query")
+    device._connection._session_id = "test"
     device._connection.query.side_effect = [
         {
             "last_id": 3,
@@ -222,6 +223,7 @@ def test_device_update_state_machine_disarmed(client, mocker):
     """Should check if the state machine is properly updated after calling update()."""
     device = AlarmDevice(client)
     mocker.patch.object(device._connection, "query")
+    device._connection._session_id = "test"
     device._connection.query.side_effect = [
         {
             "last_id": 3,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -33,6 +33,7 @@ def test_device_constructor(client):
     assert device.sectors_disarmed == {}
     assert device.inputs_alerted == {}
     assert device.inputs_wait == {}
+    assert device.alerts == {}
 
 
 def test_device_constructor_with_config(client):
@@ -161,6 +162,33 @@ def test_device_update_success(client, mocker):
     inputs_wait = {
         2: {"id": 3, "index": 2, "element": 3, "excluded": True, "status": False, "name": "Outdoor Sensor 2"}
     }
+    alerts = {
+        "alarm_led": 0,
+        "anomalies_led": 1,
+        "device_failure": 0,
+        "device_low_battery": 0,
+        "device_no_power": 0,
+        "device_no_supervision": 0,
+        "device_system_block": 0,
+        "device_tamper": 0,
+        "gsm_anomaly": 0,
+        "gsm_low_balance": 0,
+        "has_anomaly": False,
+        "input_alarm": 0,
+        "input_bypass": 0,
+        "input_failure": 0,
+        "input_low_battery": 0,
+        "input_no_supervision": 0,
+        "inputs_led": 2,
+        "module_registration": 0,
+        "panel_low_battery": 0,
+        "panel_no_power": 0,
+        "panel_tamper": 0,
+        "pstn_anomaly": 0,
+        "rf_interference": 0,
+        "system_test": 0,
+        "tamper_led": 0,
+    }
     device.connect("username", "password")
     # Test
     device.update()
@@ -169,6 +197,7 @@ def test_device_update_success(client, mocker):
     assert device.sectors_disarmed == sectors_disarmed
     assert device.inputs_alerted == inputs_alerted
     assert device.inputs_wait == inputs_wait
+    assert device.alerts == alerts
     assert device._lastIds == {
         q.SECTORS: 4,
         q.INPUTS: 42,


### PR DESCRIPTION
### Related Issues

- Closes #36 

### Proposed Changes:

This change leverages `econnect-python` to retrieve the system global state. It includes a list of errors, anomalies and triggered input/output so that you can build automations on top of it. The following is a list of generated entities:
```
binary_sensor.anomalies_led
binary_sensor.inputs_led
binary_sensor.alarm_led
binary_sensor.tamper_led
binary_sensor.has_anomaly
binary_sensor.panel_tamper
binary_sensor.panel_no_power
binary_sensor.panel_low_battery
binary_sensor.gsm_anomaly
binary_sensor.gsm_low_balance
binary_sensor.pstn_anomaly
binary_sensor.system_test
binary_sensor.module_registration
binary_sensor.rf_interference
binary_sensor.input_failure
binary_sensor.input_alarm
binary_sensor.input_bypass
binary_sensor.input_low_battery
binary_sensor.input_no_supervision
binary_sensor.device_tamper
binary_sensor.device_failure
binary_sensor.device_no_power
binary_sensor.device_low_battery
binary_sensor.device_no_supervision
binary_sensor.device_system_block
```

### Testing:

Install this PR and check your entities page.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
