### PR TITLE
feat(collector): support configurable scan interval to reduce data usage

### DIFF
--- a/custom_components/elmo_iess_alarm/__init__.py
+++ b/custom_components/elmo_iess_alarm/__init__.py
@@ -14,13 +14,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_DOMAIN,
+    CONF_SCAN_INTERVAL,
     CONF_SYSTEM_URL,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE,
     KEY_UNSUBSCRIBER,
     POLLING_TIMEOUT,
-    SCAN_INTERVAL,
+    SCAN_INTERVAL_DEFAULT,
 )
 from .devices import AlarmDevice
 
@@ -89,11 +90,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             await hass.async_add_executor_job(device.connect, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
             _LOGGER.info("Token was invalid or expired, re-authentication executed.")
 
+    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="elmo_iess_alarm",
-        update_interval=timedelta(seconds=SCAN_INTERVAL),
+        update_interval=timedelta(seconds=scan_interval),
         update_method=async_update_data,
     )
 

--- a/custom_components/elmo_iess_alarm/config_flow.py
+++ b/custom_components/elmo_iess_alarm/config_flow.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_AREAS_ARM_NIGHT,
     CONF_AREAS_ARM_VACATION,
     CONF_DOMAIN,
+    CONF_SCAN_INTERVAL,
     CONF_SYSTEM_NAME,
     CONF_SYSTEM_URL,
     DOMAIN,
@@ -131,6 +132,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         suggest_arm_vacation = user_input.get(CONF_AREAS_ARM_VACATION) or self.config_entry.options.get(
             CONF_AREAS_ARM_VACATION
         )
+        suggest_scan_interval = user_input.get(CONF_SCAN_INTERVAL) or self.config_entry.options.get(CONF_SCAN_INTERVAL)
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -147,6 +149,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_AREAS_ARM_VACATION,
                         description={"suggested_value": suggest_arm_vacation},
                     ): str,
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        description={"suggested_value": suggest_scan_interval},
+                    ): int,
                 }
             ),
             errors=errors,

--- a/custom_components/elmo_iess_alarm/const.py
+++ b/custom_components/elmo_iess_alarm/const.py
@@ -11,11 +11,12 @@ CONF_SYSTEM_NAME = "system_name"
 CONF_AREAS_ARM_HOME = "areas_arm_home"
 CONF_AREAS_ARM_NIGHT = "areas_arm_night"
 CONF_AREAS_ARM_VACATION = "areas_arm_vacation"
+CONF_SCAN_INTERVAL = "scan_interval"
 DOMAIN = "elmo_iess_alarm"
 KEY_DEVICE = "device"
 KEY_COORDINATOR = "coordinator"
 KEY_UNSUBSCRIBER = "options_unsubscriber"
-# Fast scanning is fine because long-polling is used
-# and lasts 15 seconds
-SCAN_INTERVAL = 5
+# Defines the default scan interval in seconds.
+# Fast scanning is required for real-time updates of the alarm state.
+SCAN_INTERVAL_DEFAULT = 5
 POLLING_TIMEOUT = 20

--- a/custom_components/elmo_iess_alarm/strings.json
+++ b/custom_components/elmo_iess_alarm/strings.json
@@ -32,9 +32,10 @@
             "data": {
               "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
               "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-              "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)"
+              "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+              "scan_interval": "Scan interval (e.g. 120 - optional)"
             },
-            "description": "Define sectors you want to arm in different modes.",
+            "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
             "title": "Configure your Elmo/IESS system"
           }
       }

--- a/custom_components/elmo_iess_alarm/translations/en.json
+++ b/custom_components/elmo_iess_alarm/translations/en.json
@@ -32,9 +32,10 @@
                 "data": {
                     "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
                     "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-                    "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)"
+                    "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+                    "scan_interval": "Scan interval (e.g. 120 - optional)"
                 },
-                "description": "Define sectors you want to arm in different modes.",
+                "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
                 "title": "Configure your Elmo/IESS system"
             }
         }

--- a/custom_components/elmo_iess_alarm/translations/it.json
+++ b/custom_components/elmo_iess_alarm/translations/it.json
@@ -32,9 +32,10 @@
                 "data": {
                     "areas_arm_home": "Settori armati mentre sei a casa (es. 3,4 - opzionale)",
                     "areas_arm_night": "Settori armati di notte (es. 3,4 - opzionale)",
-                    "areas_arm_vacation": "Settori armati quando sei in vacanza (es. 3,4 - opzionale)"
+                    "areas_arm_vacation": "Settori armati quando sei in vacanza (es. 3,4 - opzionale)",
+                    "scan_interval": "Intervallo di scansione (es. 120 - opzionale)"
                 },
-                "description": "Definisci i settori che desideri armare in diverse modalità.",
+                "description": "Definisci i settori che desideri armare in diverse modalità.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
                 "title": "Configura il tuo sistema Elmo/IESS"
             }
         }


### PR DESCRIPTION
### Related Issues

- Closes #23 

### Proposed Changes:

This change introduces a new optional variable `SCAN_INTERVAL` that let users to change how often the system is updated. This closes the high data usage issue as there is no other way, at the time of writing, to handle this specific case.

### Testing:

Open the integration configuration page and set a scan interval.

### Extra Notes (optional):

Unfortunately, this solution is suboptimal. Currently the system works that way:
1. The system and the cloud don't communicate often with a very minimum data consumption
2. When any system (mobile app, webapp or this integration) asks for a status update (poll), the cloud forces the system to provide the latest update
3. As this integration provides real-time updates, the default scan interval asks for the update every 5 seconds with a long-polling that lasts 15 seconds.
4. The integration doesn't consume data, but indirectly forces the cloud to ask the system for data every 5-15 seconds that is a lot if your system is connected through a mobile network.

As the communication between the system and the cloud is out of scope for this integration, the only way to reduce data is just to ask for less. The downside is that with a high `SCAN_INTERVAL` the integration stops to be real-time and so some automations may trigger later, or you may see discrepancies between the detected value and the real state.

### Checklist

- [x] Related issues and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
