### PR TITLE
Changed how to handle sectors and inputs

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -27,16 +27,16 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     # Load all entities and register sectors and inputs
     # TODO: use a public API (change in econnect-python)
-    # TODO: check why I can't use directly the device (maybe it's not loaded at this time)
-    sensors = []
-    inventory = await hass.async_add_executor_job(device._connection._get_descriptions)
-    for sector_id, name in inventory[query.SECTORS].items():
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{sector_id}"
-        sensors.append(EconnectDoorWindowSensor(unique_id, sector_id, entry, name, coordinator, device, query.SECTORS))
 
-    for sensor_id, name in inventory[query.INPUTS].items():
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{sensor_id}"
-        sensors.append(EconnectDoorWindowSensor(unique_id, sensor_id, entry, name, coordinator, device, query.INPUTS))
+    sensors = []
+
+    for id, name in device.sectors_configured.items():
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{id}"
+        sensors.append(EconnectDoorWindowSensor(unique_id, id, entry, name, coordinator, device, query.SECTORS))
+
+    for id, name in device.inputs_configured.items():
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{id}"
+        sensors.append(EconnectDoorWindowSensor(unique_id, id, entry, name, coordinator, device, query.INPUTS))
 
     # Retrieve alarm system global status
     alerts = await hass.async_add_executor_job(device._connection.get_status)

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from requests.exceptions import HTTPError
 
 from .const import CONF_AREAS_ARM_HOME, CONF_AREAS_ARM_NIGHT, CONF_AREAS_ARM_VACATION
-from .helpers import parse_areas_config
+from .helpers import filter_dict_key, parse_areas_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,6 +58,8 @@ class AlarmDevice:
         self.sectors_disarmed = {}
         self.inputs_alerted = {}
         self.inputs_wait = {}
+        self.inputs_configured = {}
+        self.sectors_configured = {}
 
     def connect(self, username, password):
         """Establish a connection with the E-connect backend, to retrieve an access
@@ -155,6 +157,8 @@ class AlarmDevice:
             raise
 
         # Filter sectors and inputs
+        self.inputs_configured = filter_dict_key(inputs["inputs"], "name")
+        self.sectors_configured = filter_dict_key(sectors["sectors"], "name")
         self.sectors_armed = _filter_data(sectors, "sectors", True)
         self.sectors_disarmed = _filter_data(sectors, "sectors", False)
         self.inputs_alerted = _filter_data(inputs, "inputs", True)

--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -101,3 +101,24 @@ def generate_entity_id(config: ConfigEntry, name: Union[str, None] = None) -> st
     # See: https://www.home-assistant.io/faq/unique_id/#can-be-changed
     entity_name = slugify(f"{system_name}_{additional_name}")
     return f"{DOMAIN}.{DOMAIN}_{entity_name}"
+
+
+def filter_dict_key(dict: dict, search_key: str):
+    """
+    Filters a dictionary based on a specified search key.
+
+    Args:
+        dict (dict): The input dictionary to be filtered.
+        search_key (str): The key to filter the dictionary.
+
+    Returns:
+        dict: A new dictionary containing only the specified key-value pairs.
+
+    Example:
+        >>> my_dict = {'a': {'x': 1, 'y': 2}, 'b': {'x': 3, 'y': 4}}
+        >>> filter_dict_key(my_dict, 'x')
+        {'a': 1, 'b': 3}
+    """
+    filtered_dict = {k: v[key] for k, v in dict.items() for key in [search_key]}
+
+    return filtered_dict

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -29,6 +29,8 @@ def test_device_constructor(client):
     assert device._sectors_night == []
     assert device._sectors_vacation == []
     assert device.state == STATE_UNAVAILABLE
+    assert device.sectors_configured == {}
+    assert device.inputs_configured == {}
     assert device.sectors_armed == {}
     assert device.sectors_disarmed == {}
     assert device.inputs_alerted == {}
@@ -51,6 +53,8 @@ def test_device_constructor_with_config(client):
     assert device._sectors_night == [1, 2, 3]
     assert device._sectors_vacation == [5, 3]
     assert device.state == STATE_UNAVAILABLE
+    assert device.sectors_configured == {}
+    assert device.inputs_configured == {}
     assert device.sectors_armed == {}
     assert device.sectors_disarmed == {}
     assert device.inputs_alerted == {}
@@ -148,6 +152,16 @@ def test_device_update_success(client, mocker):
     """Should check store the e-connect System status in the device object."""
     device = AlarmDevice(client)
     mocker.spy(device._connection, "query")
+    sectors_configured = {
+        0: "S1 Living Room",
+        1: "S2 Bedroom",
+        2: "S3 Outdoor",
+    }
+    inputs_configured = {
+        0: "Entryway Sensor",
+        1: "Outdoor Sensor 1",
+        2: "Outdoor Sensor 2",
+    }
     sectors_armed = {
         0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
         1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
@@ -193,6 +207,8 @@ def test_device_update_success(client, mocker):
     # Test
     device.update()
     assert device._connection.query.call_count == 2
+    assert device.sectors_configured == sectors_configured
+    assert device.inputs_configured == inputs_configured
     assert device.sectors_armed == sectors_armed
     assert device.sectors_disarmed == sectors_disarmed
     assert device.inputs_alerted == inputs_alerted

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@ from homeassistant.core import valid_entity_id
 
 from custom_components.econnect_metronet.exceptions import InvalidAreas
 from custom_components.econnect_metronet.helpers import (
+    filter_dict_key,
     generate_entity_id,
     parse_areas_config,
 )
@@ -81,3 +82,7 @@ def test_generate_entity_name_with_spaces(config_entry):
     entity_id = generate_entity_id(config_entry)
     assert entity_id == "econnect_metronet.econnect_metronet_home_assistant"
     assert valid_entity_id(entity_id)
+
+
+def test_filter_dict_key():
+    assert filter_dict_key({0: {"b": 1, "c": 2, "d": 3}}, "d") == {0: 3}


### PR DESCRIPTION
### Related Issues

Create binary_sensor only for configured sectors #59

### Proposed Changes:
I have modified how sectors and inputs binary sensors are created
Now the integration create only binary sensors for sectors that are configured in control panel

Screenshoot of binary sensors with original code:
![after](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/f30449e0-508e-4a25-8eb4-208a1088bffc)

Screenshoot of binary sensors with modified code:
![before](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/327fd588-7691-4bab-9611-9322567eec9f)

### Testing:
Nothing is changed for the user configuration


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
