### PR TITLE
ci(release): all packages are built during the release action

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Build test package
         run: hatch -v build -t sdist
 
+      - name: Build the release candidate package
+        run: hatch -v build -t zipped-directory
+
       - name: Log package content
         run: tar -tvf dist/econnect_metronet-$PKG_VERSION.tar.gz
 
@@ -45,13 +48,3 @@ jobs:
 
       - name: Test if the package is built correctly
         run: python -c "import custom_components.econnect_metronet"
-
-      - name: Build the release package
-        run: hatch -v build -t zipped-directory
-
-      - name: Upload release archive
-        uses: actions/upload-artifact@v3
-        with:
-          name: econnect-metronet-${{ env.PKG_VERSION }}.zip
-          path: dist/econnect_metronet-${{ env.PKG_VERSION }}.zip
-          if-no-files-found: error

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,12 +19,24 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3.5.3
 
-      - name: Build Integration ZIP package
+      - name: Detect package version
+        run: echo "PKG_VERSION=$(hatch version)" >> "$GITHUB_ENV"
+
+      - name: Build release package (tar)
+        run: hatch -v build -t sdist
+
+      - name: Build release package (zip)
+        run: hatch -v build -t zipped-directory
+
+      - name: Build release package (HACS)
         run: |
           cd ${{ github.workspace }}/custom_components/econnect_metronet
           zip hacs_econnect_metronet.zip -r ./
 
-      - name: Upload ZIP package release
+      - name: Upload release packages
         uses: softprops/action-gh-release@v0.1.15
         with:
-          files: ${{ github.workspace }}/custom_components/econnect_metronet/hacs_econnect_metronet.zip
+          files: |
+            ${{ github.workspace }}/dist/econnect_metronet-$PKG_VERSION.tar.gz
+            ${{ github.workspace }}/dist/econnect_metronet-$PKG_VERSION.zip
+            ${{ github.workspace }}/custom_components/econnect_metronet/hacs_econnect_metronet.zip


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

In this update, we've refined our CI/CD process. Rather than uploading an artifact during the `building` workflow, we now upload the package directly to the release when it's triggered. This ensures that the `building` workflow remains focused solely on verifying the integrity and success of the build step.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [ ] Code is well-documented via docstrings
