### PR TITLE
fix(collector): force update when connection is unstable

### DIFF
--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -46,11 +46,11 @@ class AlarmCoordinator(DataUpdateCoordinator):
         fails. Additionally logging is handled by config entry setup
         to ensure that multiple retries do not cause log spam.
         """
-        _LOGGER.debug("Coordinator | First authentication")
         username = self.config_entry.data[CONF_USERNAME]
         password = self.config_entry.data[CONF_PASSWORD]
         await self.hass.async_add_executor_job(self.device.connect, username, password)
-        _LOGGER.debug("Coordinator | Authentication successful")
+        _LOGGER.debug("Coordinator | First authentication successful")
+        await self.hass.async_add_executor_job(self.device.update)
         return await super().async_config_entry_first_refresh()
 
     async def _async_update_data(self):

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -1,0 +1,71 @@
+import logging
+from datetime import timedelta
+
+import async_timeout
+from elmo.api.client import ElmoClient
+from elmo.api.exceptions import InvalidToken
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import (
+    CONF_DOMAIN,
+    CONF_SCAN_INTERVAL,
+    CONF_SYSTEM_URL,
+    DOMAIN,
+    POLLING_TIMEOUT,
+    SCAN_INTERVAL_DEFAULT,
+)
+from .devices import AlarmDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AlarmCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass: HomeAssistant, config: ConfigEntry):
+        # Initialize all clients and devices
+        client = ElmoClient(config.data[CONF_SYSTEM_URL], config.data[CONF_DOMAIN])
+        scan_interval = config.options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
+
+        # Attributes
+        self.device = AlarmDevice(client, config.options)
+
+        # Configure the coordinator
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_update_data(self):
+        try:
+            # `device.has_updates` implements e-Connect long-polling API. This
+            # action blocks the thread for 15 seconds, or when the backend publishes an update
+            # POLLING_TIMEOUT ensures an upper bound regardless of the underlying implementation.
+            async with async_timeout.timeout(POLLING_TIMEOUT):
+                status = await self.hass.async_add_executor_job(self.device.has_updates)
+                if status["has_changes"]:
+                    _LOGGER.debug("Coordinator | Changes detected, sending an update")
+                    # State machine is in `device.state`
+                    return await self.hass.async_add_executor_job(self.device.update)
+                else:
+                    _LOGGER.debug("Coordinator | No changes detected")
+                    return None
+        except InvalidToken:
+            _LOGGER.debug("Coordinator | Invalid token detected, authenticating")
+            username = self.config_entry.data[CONF_USERNAME]
+            password = self.config_entry.data[CONF_PASSWORD]
+            await self.hass.async_add_executor_job(self.device.connect, username, password)
+            _LOGGER.debug("Coordinator | Authentication completed with success")
+            return await self.hass.async_add_executor_job(self.device.update)
+        except UpdateFailed:
+            # Resetting the connection, forces an update during the next run. This is required to prevent
+            # a misalignment between the `AlarmDevice` and backend known IDs, needed to implement
+            # the long-polling strategy. If IDs are misaligned, then no updates happen and
+            # the integration remains stuck.
+            _LOGGER.debug(
+                "Coordinator | Update failed, resetting IDs to force a full update when the connection is stable"
+            )
+            self.device.reset()

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -69,3 +69,4 @@ class AlarmCoordinator(DataUpdateCoordinator):
                 "Coordinator | Update failed, resetting IDs to force a full update when the connection is stable"
             )
             self.device.reset()
+            raise

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -39,6 +39,20 @@ class AlarmCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=scan_interval),
         )
 
+    async def async_config_entry_first_refresh(self) -> None:
+        """Refresh data for the first time when a config entry is setup.
+
+        Will automatically raise ConfigEntryNotReady if the refresh
+        fails. Additionally logging is handled by config entry setup
+        to ensure that multiple retries do not cause log spam.
+        """
+        _LOGGER.debug("Coordinator | First authentication")
+        username = self.config_entry.data[CONF_USERNAME]
+        password = self.config_entry.data[CONF_PASSWORD]
+        await self.hass.async_add_executor_job(self.device.connect, username, password)
+        _LOGGER.debug("Coordinator | Authentication successful")
+        return await super().async_config_entry_first_refresh()
+
     async def _async_update_data(self):
         try:
             # `device.has_updates` implements e-Connect long-polling API. This

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -49,9 +49,8 @@ class AlarmCoordinator(DataUpdateCoordinator):
         username = self.config_entry.data[CONF_USERNAME]
         password = self.config_entry.data[CONF_PASSWORD]
         await self.hass.async_add_executor_job(self.device.connect, username, password)
-        _LOGGER.debug("Coordinator | First authentication successful")
         await self.hass.async_add_executor_job(self.device.update)
-        return await super().async_config_entry_first_refresh()
+        _LOGGER.debug("Coordinator | First authentication and update are successful")
 
     async def _async_update_data(self):
         try:
@@ -59,6 +58,7 @@ class AlarmCoordinator(DataUpdateCoordinator):
             # action blocks the thread for 15 seconds, or when the backend publishes an update
             # POLLING_TIMEOUT ensures an upper bound regardless of the underlying implementation.
             async with async_timeout.timeout(POLLING_TIMEOUT):
+                _LOGGER.debug("Coordinator | Waiting for changes (long-polling)")
                 status = await self.hass.async_add_executor_job(self.device.has_updates)
                 if status["has_changes"]:
                     _LOGGER.debug("Coordinator | Changes detected, sending an update")

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -40,10 +40,9 @@ class AlarmDevice:
         self._sectors_home = []
         self._sectors_night = []
         self._sectors_vacation = []
-        self._lastIds = {
-            q.SECTORS: 0,
-            q.INPUTS: 0,
-        }
+
+        # Set last known IDs used for the long-polling API
+        self.reset()
 
         # Load user configuration
         if config is not None:
@@ -59,6 +58,15 @@ class AlarmDevice:
         self.inputs_alerted = {}
         self.inputs_wait = {}
         self._inventory = {}
+
+    def reset(self):
+        """Simulates a connection reset where IDs are set to the same value when
+        a reset happens.
+        """
+        self._lastIds = {
+            q.SECTORS: 0,
+            q.INPUTS: 0,
+        }
 
     def connect(self, username, password):
         """Establish a connection with the E-connect backend, to retrieve an access

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -78,18 +78,25 @@ class AlarmDevice:
             raise err
 
     def has_updates(self):
-        """Use the connection to detect a possible change. This is a blocking call
-        that must not be called in the main thread. Check `ElmoClient.poll()` method
-        for more details.
+        """Check if there have been any updates using the established connection.
 
-        Values passed to `ElmoClient.poll()` are the last known IDs for sectors and
-        inputs. A new dictionary is sent to avoid the underlying client to mutate
-        the device internal state.
+        This method uses the connection to detect possible changes. It's a blocking
+        call that requests for the system unit status to detect possible connection issues,
+        and then polls for updates. The method blocks for 15 seconds and it should not be
+        invoked from the main thread.
+
+        Raises:
+            HTTPError: If there's an error while polling for updates.
+            ParseError: If there's an error parsing the poll response.
+
+        Returns:
+            dict: Dictionary with the updates if any, based on the last known IDs.
         """
         try:
-            return self._connection.poll({x: y for x, y in self._lastIds.items()})
+            self._connection.get_status()
+            return self._connection.poll({key: value for key, value in self._lastIds.items()})
         except HTTPError as err:
-            _LOGGER.error(f"Device | Error while checking if there are updates: {err}")
+            _LOGGER.error(f"Device | Error while polling for updates: {err.response.text}")
             raise err
         except ParseError as err:
             _LOGGER.error(f"Device | Error parsing the poll response: {err}")
@@ -151,9 +158,12 @@ class AlarmDevice:
             sectors = self._connection.query(q.SECTORS)
             inputs = self._connection.query(q.INPUTS)
             alerts = self._connection.get_status()
-        except (HTTPError, ParseError) as err:
-            _LOGGER.error(f"Device | Error while checking if there are updates: {err}")
-            raise
+        except HTTPError as err:
+            _LOGGER.error(f"Device | Error during the update: {err.response.text}")
+            raise err
+        except ParseError as err:
+            _LOGGER.error(f"Device | Error during the update: {err}")
+            raise err
 
         # Update the _inventory
         self._inventory.update({"inputs": inputs["inputs"]})
@@ -181,7 +191,7 @@ class AlarmDevice:
                 self._connection.arm(sectors=sectors)
                 self.state = STATE_ALARM_ARMED_AWAY
         except HTTPError as err:
-            _LOGGER.error(f"Device | Error while arming the system: {err}")
+            _LOGGER.error(f"Device | Error while arming the system: {err.response.text}")
             raise err
         except LockError as err:
             _LOGGER.error(f"Device | Error while acquiring the system lock: {err}")
@@ -196,7 +206,7 @@ class AlarmDevice:
                 self._connection.disarm(sectors=sectors)
                 self.state = STATE_ALARM_DISARMED
         except HTTPError as err:
-            _LOGGER.error(f"Device | Error while disarming the system: {err}")
+            _LOGGER.error(f"Device | Error while disarming the system: {err.response.text}")
             raise err
         except LockError as err:
             _LOGGER.error(f"Device | Error while acquiring the system lock: {err}")

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -193,6 +193,8 @@ class AlarmDevice:
         # Update the internal state machine (mapping state)
         self.state = self.get_state()
 
+        return self._inventory
+
     def arm(self, code, sectors=None):
         try:
             with self._connection.lock(code):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pre-commit",
   # Test
   "pytest",
+  "pytest-asyncio",
   "pytest-cov",
   "pytest-mock",
   "responses",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,8 +118,15 @@ def config_entry():
 
     class MockConfigEntry:
         def __init__(self):
+            # Config at install-time
             self.data = {
                 "username": "test_user",
+                "password": "test_password",
+                "system_base_url": "https://example.com",
+                "domain": "econnect_metronet",
             }
+
+            # Options at configuration-time
+            self.options = {}
 
     return MockConfigEntry()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from elmo.api.client import ElmoClient
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
+from custom_components.econnect_metronet.coordinator import AlarmCoordinator
 from custom_components.econnect_metronet.devices import AlarmDevice
 
 from .fixtures import responses as r
@@ -56,6 +57,27 @@ def alarm_entity(hass, client, config_entry):
     entity = EconnectAlarm(unique_id="test_id", config=config_entry, device=device, coordinator=coordinator)
     entity.hass = hass
     yield entity
+
+
+@pytest.fixture(scope="function")
+def coordinator(hass, config_entry, alarm_device):
+    """Fixture to provide a test instance of the AlarmCoordinator.
+
+    This sets up an AlarmDevice and its corresponding DataUpdateCoordinator.
+
+    Args:
+        hass: Mock Home Assistant instance.
+        config_entry: Mock config entry.
+
+    Yields:
+        AlarmCoordinator: Initialized test instance of the AlarmCoordinator.
+    """
+    coordinator = AlarmCoordinator(hass, config_entry)
+    # Override Configuration and Device with mocked versions
+    coordinator.config_entry = config_entry
+    coordinator.device = alarm_device
+    coordinator.device._connection._session_id = "test_token"
+    yield coordinator
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,108 @@
+from datetime import timedelta
+
+import pytest
+from elmo.api.exceptions import InvalidToken
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.econnect_metronet.coordinator import AlarmCoordinator
+from custom_components.econnect_metronet.devices import AlarmDevice
+
+
+def test_coordinator_constructor(hass, config_entry):
+    # Ensure that the coordinator is initialized correctly
+    coordinator = AlarmCoordinator(hass, config_entry)
+    assert coordinator.name == "econnect_metronet"
+    assert coordinator.update_interval == timedelta(seconds=5)
+    assert isinstance(coordinator.device, AlarmDevice)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_no_data(mocker, coordinator):
+    # Ensure that the coordinator returns an empty list if no changes are detected
+    mocker.patch.object(coordinator.device, "has_updates")
+    coordinator.device.has_updates.return_value = {"has_changes": False}
+    # Test
+    await coordinator.async_refresh()
+    assert coordinator.data is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_with_data(mocker, coordinator):
+    # Ensure that the coordinator returns data when changes are detected
+    mocker.patch.object(coordinator.device, "has_updates")
+    coordinator.device.has_updates.return_value = {"has_changes": True}
+    # Test
+    await coordinator.async_refresh()
+    assert coordinator.data == {
+        "alerts": {
+            "alarm_led": 0,
+            "anomalies_led": 1,
+            "device_failure": 0,
+            "device_low_battery": 0,
+            "device_no_power": 0,
+            "device_no_supervision": 0,
+            "device_system_block": 0,
+            "device_tamper": 0,
+            "gsm_anomaly": 0,
+            "gsm_low_balance": 0,
+            "has_anomaly": False,
+            "input_alarm": 0,
+            "input_bypass": 0,
+            "input_failure": 0,
+            "input_low_battery": 0,
+            "input_no_supervision": 0,
+            "inputs_led": 2,
+            "module_registration": 0,
+            "panel_low_battery": 0,
+            "panel_no_power": 0,
+            "panel_tamper": 0,
+            "pstn_anomaly": 0,
+            "rf_interference": 0,
+            "system_test": 0,
+            "tamper_led": 0,
+        },
+        "inputs": {
+            0: {"element": 1, "excluded": False, "id": 1, "index": 0, "name": "Entryway Sensor", "status": True},
+            1: {"element": 2, "excluded": False, "id": 2, "index": 1, "name": "Outdoor Sensor 1", "status": True},
+            2: {"element": 3, "excluded": True, "id": 3, "index": 2, "name": "Outdoor Sensor 2", "status": False},
+        },
+        "sectors": {
+            0: {"element": 1, "excluded": False, "id": 1, "index": 0, "name": "S1 Living Room", "status": True},
+            1: {"element": 2, "excluded": False, "id": 2, "index": 1, "name": "S2 Bedroom", "status": True},
+            2: {"element": 3, "excluded": False, "id": 3, "index": 2, "name": "S3 Outdoor", "status": False},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_invalid_token(mocker, coordinator):
+    # Ensure a new connection is established when the token is invalid
+    mocker.patch.object(coordinator.device, "has_updates")
+    coordinator.device.has_updates.side_effect = InvalidToken()
+    mocker.spy(coordinator.device, "connect")
+    # Test
+    await coordinator._async_update_data()
+    coordinator.device.connect.assert_called_once_with("test_user", "test_password")
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_failed(mocker, coordinator):
+    # Resetting the connection, forces an update during the next run. This is required to prevent
+    # a misalignment between the `AlarmDevice` and backend known IDs, needed to implement
+    # the long-polling strategy. If IDs are misaligned, then no updates happen and
+    # the integration remains stuck.
+    # Regression test for: https://github.com/palazzem/ha-econnect-alarm/issues/51
+    mocker.patch.object(coordinator.device, "has_updates")
+    coordinator.device.has_updates.side_effect = UpdateFailed()
+    mocker.spy(coordinator.device, "reset")
+    coordinator.device._lastIds = {
+        9: 42,
+        10: 42,
+    }
+    # Test
+    await coordinator._async_update_data()
+    assert coordinator.device.reset.call_count == 1
+    assert coordinator.device._lastIds == {
+        9: 0,
+        10: 0,
+    }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -108,3 +108,12 @@ async def test_coordinator_async_update_failed(mocker, coordinator):
         9: 0,
         10: 0,
     }
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_auth(mocker, coordinator):
+    # Ensure the first refresh authenticates before joining the scheduler
+    mocker.spy(coordinator.device, "connect")
+    # Test
+    await coordinator.async_config_entry_first_refresh()
+    coordinator.device.connect.assert_called_once_with("test_user", "test_password")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -77,6 +77,7 @@ async def test_coordinator_async_update_with_data(mocker, coordinator):
 @pytest.mark.asyncio
 async def test_coordinator_async_update_invalid_token(mocker, coordinator):
     # Ensure a new connection is established when the token is invalid
+    # No exceptions must be raised as this is a normal condition
     mocker.patch.object(coordinator.device, "has_updates")
     coordinator.device.has_updates.side_effect = InvalidToken()
     mocker.spy(coordinator.device, "connect")
@@ -100,7 +101,8 @@ async def test_coordinator_async_update_failed(mocker, coordinator):
         10: 42,
     }
     # Test
-    await coordinator._async_update_data()
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
     assert coordinator.device.reset.call_count == 1
     assert coordinator.device._lastIds == {
         9: 0,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -117,3 +117,15 @@ async def test_coordinator_first_refresh_auth(mocker, coordinator):
     # Test
     await coordinator.async_config_entry_first_refresh()
     coordinator.device.connect.assert_called_once_with("test_user", "test_password")
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_update(mocker, coordinator):
+    # Ensure the first refresh updates before joining the scheduler
+    # This is required to avoid registering entities without a proper state
+    mocker.patch.object(coordinator.device, "has_updates")
+    coordinator.device.has_updates.return_value = {"has_changes": False}
+    mocker.spy(coordinator.device, "update")
+    # Test
+    await coordinator.async_config_entry_first_refresh()
+    assert coordinator.device.update.call_count == 1

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from requests.exceptions import HTTPError
+from requests.models import Response
 
 from custom_components.econnect_metronet.const import (
     CONF_AREAS_ARM_HOME,
@@ -113,6 +114,7 @@ def test_device_has_updates_ids_immutable(client, mocker):
         ids[q.INPUTS] = 0
 
     device = AlarmDevice(client)
+    device.connect("username", "password")
     device._lastIds = {q.SECTORS: 4, q.INPUTS: 42}
     mocker.patch.object(device._connection, "poll")
     device._connection.poll.side_effect = bad_poll
@@ -125,8 +127,9 @@ def test_device_has_updates_ids_immutable(client, mocker):
 def test_device_has_updates_errors(client, mocker):
     """Should handle (log) polling errors."""
     device = AlarmDevice(client)
+    device.connect("username", "password")
     mocker.patch.object(device._connection, "poll")
-    device._connection.poll.side_effect = HTTPError("Unable to communicate with e-Connect")
+    device._connection.poll.side_effect = HTTPError(response=Response())
     # Test
     with pytest.raises(HTTPError):
         device.has_updates()
@@ -137,6 +140,7 @@ def test_device_has_updates_errors(client, mocker):
 def test_device_has_updates_parse_errors(client, mocker):
     """Should handle (log) polling errors."""
     device = AlarmDevice(client)
+    device.connect("username", "password")
     mocker.patch.object(device._connection, "poll")
     device._connection.poll.side_effect = ParseError("Error parsing the poll response")
     # Test
@@ -258,7 +262,7 @@ def test_device_inventory_update_success(client, mocker):
 def test_device_update_http_error(client, mocker):
     """Tests if device's update method raises HTTPError when querying."""
     device = AlarmDevice(client)
-    mocker.patch.object(device._connection, "query", side_effect=HTTPError("HTTP Error"))
+    mocker.patch.object(device._connection, "query", side_effect=HTTPError(response=Response()))
     with pytest.raises(HTTPError):
         device.update()
 
@@ -356,7 +360,7 @@ def test_device_arm_error(client, mocker):
     device = AlarmDevice(client)
     mocker.spy(device._connection, "lock")
     mocker.spy(device._connection, "arm")
-    device._connection.lock.side_effect = HTTPError("Unable to communicate with e-Connect")
+    device._connection.lock.side_effect = HTTPError(response=Response())
     device._connection._session_id = "test"
     # Test
     with pytest.raises(HTTPError):
@@ -413,7 +417,7 @@ def test_device_disarm_error(client, mocker):
     device = AlarmDevice(client)
     mocker.spy(device._connection, "lock")
     mocker.spy(device._connection, "disarm")
-    device._connection.lock.side_effect = HTTPError("Unable to communicate with e-Connect")
+    device._connection.lock.side_effect = HTTPError(response=Response())
     device._connection._session_id = "test"
     # Test
     with pytest.raises(HTTPError):


### PR DESCRIPTION
### Related Issues

- Closes #51 

### Proposed Changes:

This change forces a full update when `UpdateFailed` exception is detected. If that happens, very likely there is a connectivity error and there is a chance the backend considers the connection with the central unit gone. In that case, it resets last known IDs, causing the integration to not detect any new change as described in #51.

This fix is available in this commit: https://github.com/palazzem/ha-econnect-alarm/pull/68/commits/588082b455c8e005c290dce3b6c66eaf649e70b3

Instead of adding the fix, this PR also refactors entirely how the `DataUpdateCoordinator` is exposed to the integration, so that now it's a self contained coordinator called `AlarmCoordinator`. The coordinator is fully tested and a regression test is added to the test suite.

### Testing:

- Install the latest version that includes this change
- Produce updates for 1-2 minutes (e.g. trigger some inputs)
- Test 1: disconnect the central unit and reconnect immediately
- The integration must be stuck, it should recover within 5 minutes
- Produce updates for 1-2 minutes (e.g. trigger some inputs)
- Test 2: disconnect the central unit and reconnect after 5-10 minutes
- The integration must be stuck, it should recover within 5 minutes

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
