### PR TITLE
refactor: split binary sensors in their own entities

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -32,11 +32,11 @@ async def async_setup_entry(
     inventory = await hass.async_add_executor_job(device._connection._get_descriptions)
     for sector_id, name in inventory[query.SECTORS].items():
         unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{sector_id}"
-        sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device, query.SECTORS))
+        sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device))
 
     for sensor_id, name in inventory[query.INPUTS].items():
         unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{sensor_id}"
-        sensors.append(InputSensor(unique_id, sensor_id, entry, name, coordinator, device, query.INPUTS))
+        sensors.append(InputSensor(unique_id, sensor_id, entry, name, coordinator, device))
 
     # Retrieve alarm system global status
     alerts = await hass.async_add_executor_job(device._connection.get_status)
@@ -107,7 +107,6 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         name: str,
         coordinator: DataUpdateCoordinator,
         device: AlarmDevice,
-        sensor_type: int,
     ) -> None:
         """Construct."""
         super().__init__(coordinator)
@@ -116,7 +115,6 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         self._device = device
         self._unique_id = unique_id
         self._sensor_id = sensor_id
-        self._sensor_type = sensor_type
 
     @property
     def unique_id(self) -> str:
@@ -136,8 +134,6 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        # TODO: evaluate to expose a device API to get the status of a sensor
-        # instead of duplicating this sensor_type check
         return self._device.inputs_alerted.get(self._sensor_id) is not None
 
 
@@ -154,7 +150,6 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
         name: str,
         coordinator: DataUpdateCoordinator,
         device: AlarmDevice,
-        sensor_type: int,
     ) -> None:
         """Construct."""
         super().__init__(coordinator)
@@ -163,7 +158,6 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
         self._device = device
         self._unique_id = unique_id
         self._sector_id = sector_id
-        self._sensor_type = sensor_type
 
     @property
     def unique_id(self) -> str:
@@ -183,6 +177,4 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        # TODO: evaluate to expose a device API to get the status of a sensor
-        # instead of duplicating this sensor_type check
         return self._device.sectors_armed.get(self._sector_id) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,23 @@ async def hass(hass):
 
 
 @pytest.fixture(scope="function")
+def alarm_device(client):
+    """Yields an instance of AlarmDevice.
+
+    This fixture provides a scoped instance of AlarmDevice initialized with
+    the provided client.
+
+    Args:
+        client: The client used to initialize the AlarmDevice.
+
+    Yields:
+        An instance of AlarmDevice.
+    """
+    device = AlarmDevice(client)
+    yield device
+
+
+@pytest.fixture(scope="function")
 def alarm_entity(hass, client, config_entry):
     """Fixture to provide a test instance of the EconnectAlarm entity.
 

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -10,78 +10,80 @@ from custom_components.econnect_metronet.binary_sensor import (
 
 
 class TestAlertSensor:
-    def test_binary_sensor_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_name(hass, config_entry, alarm_device):
         # Ensure the alert has the right translation key
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
-    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
+        config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
-    def test_binary_sensor_entity_id(hass, config_entry, alarm_entity):
+    def test_binary_sensor_entity_id(hass, config_entry, alarm_device):
         # Ensure the alert has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
 
-    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
-        # Ensure the sensor has the right name
+    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+        # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_device)
         assert entity.icon == "hass:alarm-light"
 
 
 class TestInputSensor:
-    def test_binary_sensor_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_name(hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
-    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
+        config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
-    def test_binary_sensor_entity_id(hass, config_entry, alarm_entity):
+    def test_binary_sensor_entity_id(hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
 
-    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
-        # Ensure the sensor has the right name
+    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+        # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:electric-switch"
 
     def test_binary_sensor_off(hass, config_entry, alarm_device):
-        # ...
+        # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(hass, config_entry, alarm_device):
-        # ...
+        # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         alarm_device.inputs_alerted.update({entity._sensor_id: {}})
@@ -89,45 +91,46 @@ class TestInputSensor:
 
 
 class TestSectorSensor:
-    def test_binary_sensor_input_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_input_name(hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
-    def test_binary_sensor_input_name_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_input_name_with_system_name(hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
+        config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
-    def test_binary_sensor_input_entity_id(hass, config_entry, alarm_entity):
+    def test_binary_sensor_input_entity_id(hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
-    def test_binary_sensor_input_entity_id_with_system_name(hass, config_entry, alarm_entity):
+    def test_binary_sensor_input_entity_id_with_system_name(hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
-        # Ensure the sensor has the right name
+    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+        # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:shield-home-outline"
 
     def test_binary_sensor_off(hass, config_entry, alarm_device):
-        # ...
+        # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(hass, config_entry, alarm_device):
-        # ...
+        # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         alarm_device.sectors_armed.update({entity._sector_id: {}})

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -1,6 +1,5 @@
 import logging
 
-from elmo import query
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet.binary_sensor import (
@@ -36,56 +35,100 @@ class TestAlertSensor:
         entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
+    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
+        # Ensure the sensor has the right name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        assert entity.icon == "hass:alarm-light"
+
 
 class TestInputSensor:
     def test_binary_sensor_name(hass, config_entry, alarm_entity):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_entity):
         # The system name doesn't change the Entity name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_entity_id(hass, config_entry, alarm_entity):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
 
     def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_entity):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
+
+    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
+        # Ensure the sensor has the right name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        assert entity.icon == "hass:electric-switch"
+
+    def test_binary_sensor_off(hass, config_entry, alarm_device):
+        # ...
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        assert entity.is_on is False
+
+    def test_binary_sensor_on(hass, config_entry, alarm_device):
+        # ...
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        alarm_device.inputs_alerted.update({entity._sensor_id: {}})
+        assert entity.is_on is True
 
 
 class TestSectorSensor:
     def test_binary_sensor_input_name(hass, config_entry, alarm_entity):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_name_with_system_name(hass, config_entry, alarm_entity):
         # The system name doesn't change the Entity name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_entity_id(hass, config_entry, alarm_entity):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
     def test_binary_sensor_input_entity_id_with_system_name(hass, config_entry, alarm_entity):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"
+
+    def test_binary_sensor_icon(hass, config_entry, alarm_entity):
+        # Ensure the sensor has the right name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity)
+        assert entity.icon == "hass:shield-home-outline"
+
+    def test_binary_sensor_off(hass, config_entry, alarm_device):
+        # ...
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        assert entity.is_on is False
+
+    def test_binary_sensor_on(hass, config_entry, alarm_device):
+        # ...
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        alarm_device.sectors_armed.update({entity._sector_id: {}})
+        assert entity.is_on is True

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -4,72 +4,88 @@ from elmo import query
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet.binary_sensor import (
-    EconnectAlertSensor,
-    EconnectDoorWindowSensor,
+    AlertSensor,
+    InputSensor,
+    SectorSensor,
 )
 
 
-def test_binary_sensor_door_window_name(hass, config_entry, alarm_entity):
-    # Ensure the sensor has the right name
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectDoorWindowSensor(
-        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
-    )
-    assert entity.name == "1 Tamper Sirena"
+class TestAlertSensor:
+    def test_binary_sensor_name(hass, config_entry, alarm_entity):
+        # Ensure the alert has the right translation key
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        assert entity.translation_key == "has_anomalies"
+
+    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_entity):
+        # The system name doesn't change the translation key
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        assert entity.translation_key == "has_anomalies"
+
+    def test_binary_sensor_entity_id(hass, config_entry, alarm_entity):
+        # Ensure the alert has a valid Entity ID
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
+
+    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_entity):
+        # Ensure the Entity ID takes into consideration the system name
+        config_entry.data["system_name"] = "Home"
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
 
-def test_binary_sensor_door_window_name_with_system_name(hass, config_entry, alarm_entity):
-    # The system name doesn't change the Entity name
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectDoorWindowSensor(
-        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
-    )
-    assert entity.name == "1 Tamper Sirena"
+class TestInputSensor:
+    def test_binary_sensor_name(hass, config_entry, alarm_entity):
+        # Ensure the sensor has the right name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        assert entity.name == "1 Tamper Sirena"
+
+    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_entity):
+        # The system name doesn't change the Entity name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        assert entity.name == "1 Tamper Sirena"
+
+    def test_binary_sensor_entity_id(hass, config_entry, alarm_entity):
+        # Ensure the sensor has a valid Entity ID
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
+
+    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_entity):
+        # Ensure the Entity ID takes into consideration the system name
+        config_entry.data["system_name"] = "Home"
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
 
 
-def test_binary_sensor_door_window_entity_id(hass, config_entry, alarm_entity):
-    # Ensure the sensor has a valid Entity ID
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectDoorWindowSensor(
-        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
-    )
-    assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
+class TestSectorSensor:
+    def test_binary_sensor_input_name(hass, config_entry, alarm_entity):
+        # Ensure the sensor has the right name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        assert entity.name == "1 S1 Living Room"
 
+    def test_binary_sensor_input_name_with_system_name(hass, config_entry, alarm_entity):
+        # The system name doesn't change the Entity name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        assert entity.name == "1 S1 Living Room"
 
-def test_binary_sensor_door_window_entity_id_with_system_name(hass, config_entry, alarm_entity):
-    # Ensure the Entity ID takes into consideration the system name
-    config_entry.data["system_name"] = "Home"
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectDoorWindowSensor(
-        "test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_entity, query.INPUTS
-    )
-    assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
+    def test_binary_sensor_input_entity_id(hass, config_entry, alarm_entity):
+        # Ensure the sensor has a valid Entity ID
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
-
-def test_binary_sensor_alert_name(hass, config_entry, alarm_entity):
-    # Ensure the alert has the right translation key
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.translation_key == "has_anomalies"
-
-
-def test_binary_sensor_alert_name_with_system_name(hass, config_entry, alarm_entity):
-    # The system name doesn't change the translation key
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.translation_key == "has_anomalies"
-
-
-def test_binary_sensor_alert_entity_id(hass, config_entry, alarm_entity):
-    # Ensure the alert has a valid Entity ID
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
-
-
-def test_binary_sensor_alert_entity_id_with_system_name(hass, config_entry, alarm_entity):
-    # Ensure the Entity ID takes into consideration the system name
-    config_entry.data["system_name"] = "Home"
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="elmo_iess_alarm")
-    entity = EconnectAlertSensor("test_id", "has_anomalies", config_entry, coordinator, alarm_entity)
-    assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
+    def test_binary_sensor_input_entity_id_with_system_name(hass, config_entry, alarm_entity):
+        # Ensure the Entity ID takes into consideration the system name
+        config_entry.data["system_name"] = "Home"
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_entity, query.INPUTS)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"


### PR DESCRIPTION
### Related Issues

Create binary_sensor only for configured sectors #59

### Proposed Changes:
Separate the `EconnectDoorWindowSensor` class into 2 class named `InputSensor` and `SectorSensor` for decrease the number of if statements

### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
