### PR TITLE
refactor: create `AlarmCoordinator` to separate HA functions from the fetching logic

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -1,16 +1,11 @@
 """The E-connect Alarm integration."""
 import asyncio
 import logging
-from datetime import timedelta
 
-import async_timeout
 from elmo.api.client import ElmoClient
-from elmo.api.exceptions import InvalidToken
 from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_DOMAIN,
@@ -20,9 +15,9 @@ from .const import (
     KEY_COORDINATOR,
     KEY_DEVICE,
     KEY_UNSUBSCRIBER,
-    POLLING_TIMEOUT,
     SCAN_INTERVAL_DEFAULT,
 )
+from .coordinator import AlarmCoordinator
 from .devices import AlarmDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,19 +25,19 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["alarm_control_panel", "binary_sensor"]
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry):
+async def async_migrate_entry(hass, config: ConfigEntry):
     """Config flow migrations."""
-    _LOGGER.info(f"Migrating from version {config_entry.version}")
+    _LOGGER.info(f"Migrating from version {config.version}")
 
-    if config_entry.version == 1:
+    if config.version == 1:
         # Config initialization
-        migrated_config = {**config_entry.data}
+        migrated_config = {**config.data}
         # Migration
         migrated_config[CONF_SYSTEM_URL] = E_CONNECT_DEFAULT
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=migrated_config)
+        config.version = 2
+        hass.config_entries.async_update_entry(config, data=migrated_config)
 
-    _LOGGER.info(f"Migration to version {config_entry.version} successful")
+    _LOGGER.info(f"Migration to version {config.version} successful")
     return True
 
 
@@ -52,7 +47,7 @@ async def async_setup(hass: HomeAssistant, config: dict):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     """Set up a configuration entry for the alarm device in Home Assistant.
 
     This asynchronous method initializes an AlarmDevice instance to access the cloud service.
@@ -61,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     Args:
         hass (HomeAssistant): The Home Assistant instance.
-        entry (ConfigEntry): The configuration entry containing the setup details for the alarm device.
+        config (ConfigEntry): The configuration entry containing the setup details for the alarm device.
 
     Returns:
         bool: True if the setup was successful, False otherwise.
@@ -69,93 +64,45 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     Raises:
         Any exceptions raised by the coordinator or the setup process will be propagated up to the caller.
     """
-    # Initialize the device with an API endpoint and a vendor.
-    # Calling `device.connect` authenticates the device via an access token
-    # and asks for the first update, hence why in `async_setup_entry` there is no need
-    # to call `coordinator.async_refresh()`.
-    client = ElmoClient(entry.data[CONF_SYSTEM_URL], entry.data[CONF_DOMAIN])
-    device = AlarmDevice(client, entry.options)
-    await hass.async_add_executor_job(device.connect, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
-
-    # Execute device update in a thread pool
-    await hass.async_add_executor_job(device.update)
-
-    async def async_update_data():
-        """Fetch data from API endpoint.
-
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
-        try:
-            # `device.has_updates` implements e-Connect long-polling API. This
-            # action blocks the thread for 15 seconds, or when the backend publishes an update
-            # POLLING_TIMEOUT ensures an upper bound regardless of the underlying implementation.
-            async with async_timeout.timeout(POLLING_TIMEOUT):
-                _LOGGER.debug("Coordinator | Waiting for changes (long-polling)")
-                coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
-                if not coordinator.last_update_success:
-                    # Force an update if at least one failed. This is required to prevent
-                    # a misalignment between the `AlarmDevice` and backend IDs, needed to implement
-                    # the long-polling strategy. If IDs are misaligned, then no updates happen and
-                    # the integration remains stuck.
-                    # See: https://github.com/palazzem/ha-econnect-alarm/issues/51
-                    _LOGGER.debug("Coordinator | Resetting IDs due to a failed update")
-                    return await hass.async_add_executor_job(device.update)
-                status = await hass.async_add_executor_job(device.has_updates)
-                if status["has_changes"]:
-                    _LOGGER.debug("Coordinator | Changes detected, sending an update")
-                    # State machine is in `device.state`
-                    return await hass.async_add_executor_job(device.update)
-                else:
-                    _LOGGER.debug("Coordinator | No changes detected")
-        except InvalidToken:
-            _LOGGER.debug("Coordinator | Invalid token detected, authenticating")
-            await hass.async_add_executor_job(device.connect, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
-            _LOGGER.debug("Coordinator | Authentication completed with success")
-            return await hass.async_add_executor_job(device.update)
-
-    scan_interval = entry.options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="econnect_metronet",
-        update_interval=timedelta(seconds=scan_interval),
-        update_method=async_update_data,
-    )
+    scan_interval = config.options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
+    client = ElmoClient(config.data[CONF_SYSTEM_URL], config.data[CONF_DOMAIN])
+    device = AlarmDevice(client, config.options)
+    coordinator = AlarmCoordinator(hass, device, scan_interval)
+    await coordinator.async_config_entry_first_refresh()
 
     # Store an AlarmDevice instance to access the cloud service.
     # It includes a DataUpdateCoordinator shared across entities to get a full
     # status update with a single request.
-    hass.data[DOMAIN][entry.entry_id] = {
+    hass.data[DOMAIN][config.entry_id] = {
         KEY_DEVICE: device,
         KEY_COORDINATOR: coordinator,
     }
 
     # Register a listener when option changes
-    unsub = entry.add_update_listener(options_update_listener)
-    hass.data[DOMAIN][entry.entry_id][KEY_UNSUBSCRIBER] = unsub
+    unsub = config.add_update_listener(options_update_listener)
+    hass.data[DOMAIN][config.entry_id][KEY_UNSUBSCRIBER] = unsub
 
     for component in PLATFORMS:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, component))
+        hass.async_create_task(hass.config_entries.async_forward_entry_setup(config, component))
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, config: ConfigEntry):
     """Unload a config entry."""
     unload_ok = all(
         await asyncio.gather(
-            *[hass.config_entries.async_forward_entry_unload(entry, component) for component in PLATFORMS]
+            *[hass.config_entries.async_forward_entry_unload(config, component) for component in PLATFORMS]
         )
     )
     if unload_ok:
         # Call the options unsubscriber and remove the configuration
-        hass.data[DOMAIN][entry.entry_id][KEY_UNSUBSCRIBER]()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN][config.entry_id][KEY_UNSUBSCRIBER]()
+        hass.data[DOMAIN].pop(config.entry_id)
 
     return unload_ok
 
 
-async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+async def options_update_listener(hass: HomeAssistant, config: ConfigEntry):
     """Handle options update."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.config_entries.async_reload(config.entry_id)

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -1,0 +1,84 @@
+import logging
+from datetime import timedelta
+from typing import Any, Dict, Optional
+
+import async_timeout
+from elmo.api.exceptions import InvalidToken
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, POLLING_TIMEOUT
+from .devices import AlarmDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AlarmCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass: HomeAssistant, device: AlarmDevice, scan_interval: int) -> None:
+        # Store the device to update the state
+        self._device = device
+
+        # Configure the coordinator
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=scan_interval),
+        )
+
+    async def _async_update_data(self) -> Optional[Dict[str, Any]]:
+        """Update device data asynchronously using the long-polling method.
+
+        This method uses the e-Connect long-polling API implemented in `device.has_updates` which
+        blocks the thread for up to 15 seconds or until the backend pushes an update.
+        A timeout ensures the method doesn't hang indefinitely.
+
+        In case of invalid token, the method attempts to re-authenticate and get an update.
+        If the update fails, the connection is reset to ensure proper data alignment in subsequent runs.
+
+        Returns:
+            A dictionary containing the updated data.
+
+        Raises:
+            InvalidToken: When the token used for the connection is invalid.
+            UpdateFailed: When there's an error in updating the data.
+        """
+        try:
+            if self.data is None:
+                # First update, no need to wait for changes
+                username = self.config_entry.data[CONF_USERNAME]
+                password = self.config_entry.data[CONF_PASSWORD]
+                await self.hass.async_add_executor_job(self._device.connect, username, password)
+                return await self.hass.async_add_executor_job(self._device.update)
+
+            async with async_timeout.timeout(POLLING_TIMEOUT):
+                if not self.last_update_success:
+                    # Force an update if at least one failed. This is required to prevent
+                    # a misalignment between the `AlarmDevice` and backend IDs, needed to implement
+                    # the long-polling strategy. If IDs are misaligned, then no updates happen and
+                    # the integration remains stuck.
+                    # See: https://github.com/palazzem/ha-econnect-alarm/issues/51
+                    _LOGGER.error("Coordinator | Central unit disconnected, forcing a full update")
+                    return await self.hass.async_add_executor_job(self._device.update)
+
+                # `device.has_updates` implements e-Connect long-polling API. This
+                # action blocks the thread for 15 seconds, or when the backend publishes an update
+                # POLLING_TIMEOUT ensures an upper bound regardless of the underlying implementation.
+                _LOGGER.debug("Coordinator | Waiting for changes (long-polling)")
+                status = await self.hass.async_add_executor_job(self._device.has_updates)
+                if status["has_changes"]:
+                    _LOGGER.debug("Coordinator | Changes detected, sending an update")
+                    return await self.hass.async_add_executor_job(self._device.update)
+                else:
+                    _LOGGER.debug("Coordinator | No changes detected")
+                    return {}
+        except InvalidToken:
+            # This exception is expected to happen when the token expires. In this case,
+            # there is no need to re-raise the exception as it's a normal condition.
+            _LOGGER.debug("Coordinator | Invalid token detected, authenticating")
+            username = self.config_entry.data[CONF_USERNAME]
+            password = self.config_entry.data[CONF_PASSWORD]
+            await self.hass.async_add_executor_job(self._device.connect, username, password)
+            _LOGGER.debug("Coordinator | Authentication completed with success")
+            return await self.hass.async_add_executor_job(self._device.update)

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -199,6 +199,8 @@ class AlarmDevice:
         # Update the internal state machine (mapping state)
         self.state = self.get_state()
 
+        return self._inventory
+
     def arm(self, code, sectors=None):
         try:
             with self._connection.lock(code):

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -155,6 +155,9 @@ class AlarmDevice:
         3. Updates the last known IDs for sectors and inputs.
         4. Updates internal state for sectors' and inputs' statuses.
 
+        Returns:
+            dict: A dictionary containing the latest retrieved inventory.
+
         Raises:
             HTTPError: If there's an error while making the HTTP request.
             ParseError: If there's an error while parsing the response.

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -40,7 +40,7 @@ class AlarmDevice:
         self._sectors_home = []
         self._sectors_night = []
         self._sectors_vacation = []
-        self._lastIds = {
+        self._last_ids = {
             q.SECTORS: 0,
             q.INPUTS: 0,
         }
@@ -108,7 +108,7 @@ class AlarmDevice:
         """
         try:
             self._connection.get_status()
-            return self._connection.poll({key: value for key, value in self._lastIds.items()})
+            return self._connection.poll({key: value for key, value in self._last_ids.items()})
         except HTTPError as err:
             _LOGGER.error(f"Device | Error while polling for updates: {err.response.text}")
             raise err
@@ -164,7 +164,7 @@ class AlarmDevice:
             sectors_disarmed (dict): A dictionary of sectors that are disarmed.
             inputs_alerted (dict): A dictionary of inputs that are in an alerted state.
             inputs_wait (dict): A dictionary of inputs that are in a wait state.
-            _lastIds (dict): Updated last known IDs for sectors and inputs.
+            _last_ids (dict): Updated last known IDs for sectors and inputs.
             state (str): Updated internal state of the device.
         """
         # Retrieve sectors and inputs
@@ -190,8 +190,8 @@ class AlarmDevice:
         self.inputs_alerted = _filter_data(inputs, "inputs", True)
         self.inputs_wait = _filter_data(inputs, "inputs", False)
 
-        self._lastIds[q.SECTORS] = sectors.get("last_id", 0)
-        self._lastIds[q.INPUTS] = inputs.get("last_id", 0)
+        self._last_ids[q.SECTORS] = sectors.get("last_id", 0)
+        self._last_ids[q.INPUTS] = inputs.get("last_id", 0)
 
         # Update system alerts
         self.alerts = alerts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pre-commit",
   # Test
   "pytest",
+  "pytest-asyncio",
   "pytest-cov",
   "pytest-mock",
   "responses",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,147 @@
+from datetime import timedelta
+
+import pytest
+from elmo.api.exceptions import CredentialError, InvalidToken
+from homeassistant.exceptions import ConfigEntryNotReady
+from requests.exceptions import HTTPError
+
+from custom_components.econnect_metronet.coordinator import AlarmCoordinator
+
+
+def test_coordinator_constructor(hass, alarm_device):
+    # Ensure that the coordinator is initialized correctly
+    coordinator = AlarmCoordinator(hass, alarm_device, 42)
+    assert coordinator.name == "econnect_metronet"
+    assert coordinator.update_interval == timedelta(seconds=42)
+    assert coordinator._device is alarm_device
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_no_data(mocker, coordinator):
+    # Ensure that the coordinator returns an empty list if no changes are detected
+    mocker.patch.object(coordinator._device, "has_updates")
+    coordinator._device.has_updates.return_value = {"has_changes": False}
+    # Test
+    await coordinator.async_refresh()
+    assert coordinator.data == {}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_with_data(mocker, coordinator):
+    # Ensure that the coordinator returns data when changes are detected
+    mocker.patch.object(coordinator._device, "has_updates")
+    coordinator._device.has_updates.return_value = {"has_changes": True}
+    # Test
+    await coordinator.async_refresh()
+    assert coordinator.data == {
+        "alerts": {
+            "alarm_led": 0,
+            "anomalies_led": 1,
+            "device_failure": 0,
+            "device_low_battery": 0,
+            "device_no_power": 0,
+            "device_no_supervision": 0,
+            "device_system_block": 0,
+            "device_tamper": 0,
+            "gsm_anomaly": 0,
+            "gsm_low_balance": 0,
+            "has_anomaly": False,
+            "input_alarm": 0,
+            "input_bypass": 0,
+            "input_failure": 0,
+            "input_low_battery": 0,
+            "input_no_supervision": 0,
+            "inputs_led": 2,
+            "module_registration": 0,
+            "panel_low_battery": 0,
+            "panel_no_power": 0,
+            "panel_tamper": 0,
+            "pstn_anomaly": 0,
+            "rf_interference": 0,
+            "system_test": 0,
+            "tamper_led": 0,
+        },
+        "inputs": {
+            0: {"element": 1, "excluded": False, "id": 1, "index": 0, "name": "Entryway Sensor", "status": True},
+            1: {"element": 2, "excluded": False, "id": 2, "index": 1, "name": "Outdoor Sensor 1", "status": True},
+            2: {"element": 3, "excluded": True, "id": 3, "index": 2, "name": "Outdoor Sensor 2", "status": False},
+        },
+        "sectors": {
+            0: {"element": 1, "excluded": False, "id": 1, "index": 0, "name": "S1 Living Room", "status": True},
+            1: {"element": 2, "excluded": False, "id": 2, "index": 1, "name": "S2 Bedroom", "status": True},
+            2: {"element": 3, "excluded": False, "id": 3, "index": 2, "name": "S3 Outdoor", "status": False},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_invalid_token(mocker, coordinator):
+    # Ensure a new connection is established when the token is invalid
+    # No exceptions must be raised as this is a normal condition
+    mocker.patch.object(coordinator._device, "has_updates")
+    coordinator._device.has_updates.side_effect = InvalidToken()
+    mocker.spy(coordinator._device, "connect")
+    # Test
+    await coordinator._async_update_data()
+    coordinator._device.connect.assert_called_once_with("test_user", "test_password")
+
+
+@pytest.mark.asyncio
+async def test_coordinator_async_update_failed(mocker, coordinator):
+    # Resetting the connection, forces an update during the next run. This is required to prevent
+    # a misalignment between the `AlarmDevice` and backend known IDs, needed to implement
+    # the long-polling strategy. If IDs are misaligned, then no updates happen and
+    # the integration remains stuck.
+    # Regression test for: https://github.com/palazzem/ha-econnect-alarm/issues/51
+    coordinator.last_update_success = False
+    mocker.spy(coordinator._device, "update")
+    mocker.spy(coordinator._device, "has_updates")
+    # Test
+    await coordinator._async_update_data()
+    assert coordinator._device.update.call_count == 1
+    assert coordinator._device.has_updates.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_auth(mocker, coordinator):
+    # Ensure the first refresh authenticates before joining the scheduler
+    coordinator.data = None
+    mocker.spy(coordinator._device, "connect")
+    # Test
+    await coordinator.async_config_entry_first_refresh()
+    coordinator._device.connect.assert_called_once_with("test_user", "test_password")
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_update(mocker, coordinator):
+    # Ensure the first refresh updates before joining the scheduler
+    # This is required to avoid registering entities without a proper state
+    coordinator.data = None
+    mocker.patch.object(coordinator._device, "has_updates")
+    coordinator._device.has_updates.return_value = {"has_changes": False}
+    mocker.spy(coordinator._device, "update")
+    # Test
+    await coordinator.async_config_entry_first_refresh()
+    assert coordinator._device.update.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_auth_failed(mocker, coordinator):
+    # Ensure a configuration exception is raised if the first refresh fails
+    coordinator.data = None
+    mocker.patch.object(coordinator._device, "connect")
+    coordinator._device.connect.side_effect = CredentialError()
+    # Test
+    with pytest.raises(ConfigEntryNotReady):
+        await coordinator.async_config_entry_first_refresh()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_first_refresh_update_failed(mocker, coordinator):
+    # Ensure a configuration exception is raised if the first refresh fails
+    coordinator.data = None
+    mocker.patch.object(coordinator._device, "update")
+    coordinator._device.update.side_effect = HTTPError()
+    # Test
+    with pytest.raises(ConfigEntryNotReady):
+        await coordinator.async_config_entry_first_refresh()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -26,7 +26,7 @@ def test_device_constructor(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
-    assert device._lastIds == {q.SECTORS: 0, q.INPUTS: 0}
+    assert device._last_ids == {q.SECTORS: 0, q.INPUTS: 0}
     assert device._sectors_home == []
     assert device._sectors_night == []
     assert device._sectors_vacation == []
@@ -49,7 +49,7 @@ def test_device_constructor_with_config(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
-    assert device._lastIds == {q.SECTORS: 0, q.INPUTS: 0}
+    assert device._last_ids == {q.SECTORS: 0, q.INPUTS: 0}
     assert device._sectors_home == [3, 4]
     assert device._sectors_night == [1, 2, 3]
     assert device._sectors_vacation == [5, 3]
@@ -97,8 +97,8 @@ def test_device_has_updates(client, mocker):
     """Should call the client polling system passing the internal state."""
     device = AlarmDevice(client)
     device.connect("username", "password")
-    device._lastIds[q.SECTORS] = 20
-    device._lastIds[q.INPUTS] = 20
+    device._last_ids[q.SECTORS] = 20
+    device._last_ids[q.INPUTS] = 20
     mocker.spy(device._connection, "poll")
     # Test
     device.has_updates()
@@ -115,13 +115,13 @@ def test_device_has_updates_ids_immutable(client, mocker):
 
     device = AlarmDevice(client)
     device.connect("username", "password")
-    device._lastIds = {q.SECTORS: 4, q.INPUTS: 42}
+    device._last_ids = {q.SECTORS: 4, q.INPUTS: 42}
     mocker.patch.object(device._connection, "poll")
     device._connection.poll.side_effect = bad_poll
     # Test
     device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 4, 10: 42} == device._lastIds
+    assert {9: 4, 10: 42} == device._last_ids
 
 
 def test_device_has_updates_errors(client, mocker):
@@ -134,7 +134,7 @@ def test_device_has_updates_errors(client, mocker):
     with pytest.raises(HTTPError):
         device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 0, 10: 0} == device._lastIds
+    assert {9: 0, 10: 0} == device._last_ids
 
 
 def test_device_has_updates_parse_errors(client, mocker):
@@ -147,7 +147,7 @@ def test_device_has_updates_parse_errors(client, mocker):
     with pytest.raises(ParseError):
         device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 0, 10: 0} == device._lastIds
+    assert {9: 0, 10: 0} == device._last_ids
 
 
 def test_device_update_success(client, mocker):
@@ -204,7 +204,7 @@ def test_device_update_success(client, mocker):
     assert device.inputs_alerted == inputs_alerted
     assert device.inputs_wait == inputs_wait
     assert device.alerts == alerts
-    assert device._lastIds == {
+    assert device._last_ids == {
         q.SECTORS: 4,
         q.INPUTS: 42,
     }


### PR DESCRIPTION
### Related Issues

- Follow-up for #51 

### Proposed Changes:

This change refactors entirely how the `DataUpdateCoordinator` is exposed to the integration. Instead of writing the fetching logic inside the `async_setup_entry` as a standalone function, we moved the entire logic in a dedicated class that is easy to test. `AlarmCoordinator` is fully tested and a regression test is added to the test suite.

Furthermore, the integration now uses `async_config_entry_first_refresh()` to call the first update, so that if there are issues with the update, the integration will raise `ConfigEntryNotReady` exception, preventing the integration from loading. At that stage, the integration is flagged as "Failed to load", preventing logs spamming.

### Testing:

- Install the integration
- It should work as usual as this is just a refactoring

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
