### PR TITLE
fix: build system uploads only HACS files to prevent downloading errors

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -15,12 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -3,8 +3,9 @@ name: 'Building release package'
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -38,9 +38,6 @@ jobs:
       - name: Build test package
         run: hatch -v build -t sdist
 
-      - name: Build the release candidate package
-        run: hatch -v build -t zipped-directory
-
       - name: Log package content
         run: tar -tvf dist/econnect_metronet-$PKG_VERSION.tar.gz
 

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Test hassfest
         uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release_zip_file:
+  release:
     name: HACS release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,32 +11,13 @@ concurrency:
 
 jobs:
   release_zip_file:
-    name: Publish integration zip file asset
+    name: HACS release
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3.5.3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
-      - name: Upgrade pip and install required tools
-        run: |
-          pip install --upgrade pip
-          pip install hatch
-
-      - name: Detect package version
-        run: echo "PKG_VERSION=$(hatch version)" >> "$GITHUB_ENV"
-
-      - name: Build release package (tar)
-        run: hatch -v build -t sdist
-
-      - name: Build release package (zip)
-        run: hatch -v build -t zipped-directory
+        uses: actions/checkout@v4
 
       - name: Build release package (HACS)
         run: |
@@ -47,6 +28,4 @@ jobs:
         uses: softprops/action-gh-release@v0.1.15
         with:
           files: |
-            ${{ github.workspace }}/dist/econnect_metronet-$PKG_VERSION.tar.gz
-            ${{ github.workspace }}/dist/econnect_metronet-$PKG_VERSION.zip
             ${{ github.workspace }}/custom_components/econnect_metronet/hacs_econnect_metronet.zip

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
   "hatchling",
-  "hatch-zipped-directory",
 ]
 build-backend = "hatchling.build"
 
@@ -81,7 +80,4 @@ allow-direct-references = true
 asyncio_mode = "auto"
 
 [tool.hatch.build.targets.sdist]
-only-include = ["custom_components/econnect_metronet"]
-
-[tool.hatch.build.targets.zipped-directory]
 only-include = ["custom_components/econnect_metronet"]


### PR DESCRIPTION
### Related Issues

- Closes #75 
- Closes #77 

### Proposed Changes:

This change updates our CI release process so that:
- Only HACS packages are uploaded as release assets (this fixes users' issues).
- Removes the Hatch ZIP plugin as the ZIP package is not needed anymore.
- Builder workflow now runs at every PR and push to verify the package is installable.

### Testing:

Run the CI.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
