### PR TITLE
feat: auto-initialize tests alarm_device

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ def alarm_device(client):
 
     This fixture provides a scoped instance of AlarmDevice initialized with
     the provided client.
+    The device is connected and updated with mocked data
 
     Args:
         client: The client used to initialize the AlarmDevice.
@@ -34,6 +35,8 @@ def alarm_device(client):
         An instance of AlarmDevice.
     """
     device = AlarmDevice(client)
+    device.connect("username", "password")
+    device.update()
     yield device
 
 

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -11,68 +11,63 @@ from custom_components.econnect_metronet.binary_sensor import (
 
 class TestAlertSensor:
     def test_binary_sensor_is_on(self, hass, config_entry, alarm_device):
-        alarm_device.connect("username", "password")
-        alarm_device.update()
+        # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity.is_on is True
 
     def test_binary_sensor_is_off(self, hass, config_entry, alarm_device):
-        alarm_device.connect("username", "password")
-        alarm_device.update()
+        # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("device_failure", 2, config_entry, "device_failure", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_missing(self, hass, config_entry, alarm_device):
-        alarm_device.connect("username", "password")
-        alarm_device.update()
+        # Ensure the sensor attribute is_on has the right status False if the alert is missing
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_off(self, hass, config_entry, alarm_device):
-        alarm_device.connect("username", "password")
-        alarm_device.update()
+        # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_on(self, hass, config_entry, alarm_device):
-        alarm_device.connect("username", "password")
-        alarm_device.update()
+        # Ensure the sensor attribute is_on has the right status True
         alarm_device._inventory[11][1]["status"] = 2
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is True
 
-    def test_binary_sensor_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right translation key
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
-    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
-    def test_binary_sensor_entity_id(hass, config_entry, alarm_device):
+    def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
 
-    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+    def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
@@ -80,92 +75,92 @@ class TestAlertSensor:
 
 
 class TestInputSensor:
-    def test_binary_sensor_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
-    def test_binary_sensor_name_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
-    def test_binary_sensor_entity_id(hass, config_entry, alarm_device):
+    def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
 
-    def test_binary_sensor_entity_id_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+    def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:electric-switch"
 
-    def test_binary_sensor_off(hass, config_entry, alarm_device):
+    def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputSensor("test_id", 2, config_entry, "Outdoor Sensor 2", coordinator, alarm_device)
         assert entity.is_on is False
 
-    def test_binary_sensor_on(hass, config_entry, alarm_device):
+    def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputSensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
         alarm_device.inputs_alerted.update({entity._sensor_id: {}})
         assert entity.is_on is True
 
 
 class TestSectorSensor:
-    def test_binary_sensor_input_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_input_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
-    def test_binary_sensor_input_name_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_input_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
-    def test_binary_sensor_input_entity_id(hass, config_entry, alarm_device):
+    def test_binary_sensor_input_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
-    def test_binary_sensor_input_entity_id_with_system_name(hass, config_entry, alarm_device):
+    def test_binary_sensor_input_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"
 
-    def test_binary_sensor_icon(hass, config_entry, alarm_device):
+    def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:shield-home-outline"
 
-    def test_binary_sensor_off(hass, config_entry, alarm_device):
+    def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = SectorSensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
         assert entity.is_on is False
 
-    def test_binary_sensor_on(hass, config_entry, alarm_device):
+    def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)


### PR DESCRIPTION
### Related Issues


### Proposed Changes:
This PR make the alarm_device in tests to auto-initialize for connecting and updating data

### Testing:


### Extra Notes (optional):


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
