### PR TITLE
feat(experimental): add `force_update` as experimental setting in YAML conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode
+.vscode/

--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from elmo.api.client import ElmoClient
 from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant
 
 from .const import (
@@ -41,9 +41,14 @@ async def async_migrate_entry(hass, config: ConfigEntry):
     return True
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the E-connect Alarm component."""
-    hass.data[DOMAIN] = {}
+async def async_setup(hass: HomeAssistant, config: ConfigType):
+    """Initialize the E-connect Alarm integration.
+
+    This method exposes eventual YAML configuration options under the DOMAIN key.
+    Use YAML configurations only to expose experimental settings, otherwise use
+    the configuration flow.
+    """
+    hass.data[DOMAIN] = config.get(DOMAIN, {})
     return True
 
 

--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -61,6 +61,9 @@ class AlertSensor(CoordinatorEntity, BinarySensorEntity):
         device: AlarmDevice,
     ) -> None:
         """Construct."""
+        # Enable experimental settings from the configuration file
+        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)
         self._name = name
@@ -113,6 +116,9 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         device: AlarmDevice,
     ) -> None:
         """Construct."""
+        # Enable experimental settings from the configuration file
+        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)
         self._name = name
@@ -156,6 +162,9 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
         device: AlarmDevice,
     ) -> None:
         """Construct."""
+        # Enable experimental settings from the configuration file
+        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)
         self._name = name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import responses
 from elmo.api.client import ElmoClient
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from custom_components.econnect_metronet import async_setup
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
 from custom_components.econnect_metronet.coordinator import AlarmCoordinator
 from custom_components.econnect_metronet.devices import AlarmDevice
@@ -16,6 +17,13 @@ pytest_plugins = ["tests.hass.fixtures"]
 
 @pytest.fixture
 async def hass(hass):
+    """Create a Home Assistant instance for testing.
+
+    This fixture forces some settings to simulate a bootstrap process:
+    - `custom_components` is reset to properly test the integration
+    - `async_setup()` method is called
+    """
+    await async_setup(hass, {})
     hass.data["custom_components"] = None
     yield hass
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,15 @@
+from custom_components.econnect_metronet.binary_sensor import AlertSensor
+from custom_components.econnect_metronet.const import DOMAIN
+
+
+class TestExperiments:
+    def test_sensor_force_update_default(self, coordinator, config_entry, alarm_device):
+        # Ensure the default is to not force any update
+        entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
+        assert entity._attr_force_update is False
+
+    def test_sensor_force_update_on(self, hass, coordinator, config_entry, alarm_device):
+        # Ensure you can force the entity update
+        hass.data[DOMAIN] = {"force_update": True}
+        entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
+        assert entity._attr_force_update is True


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

This change introduces the concept of having experimental settings in the YAML configuration. YAML configurations are not meant to be used by integrations, which should use always the configuration flow.

In that case, we use a not suggested method to provide settings we don't want to expose easily to end users. In this way we can ship settings we can add/remove/break based on the need.

With this change you can force HA to update sensors data even if previous/actual states are the same.

### Testing:

Update your `configuration.yaml` with the following code:

```yaml
econnect_metronet:
    force_update: true
```

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
