### PR TITLE
fix(experimental): namespace experimental settings under `experimental` key

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -12,7 +12,13 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_DEVICE
+from .const import (
+    CONF_EXPERIMENTAL,
+    CONF_FORCE_UPDATE,
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_DEVICE,
+)
 from .devices import AlarmDevice
 from .helpers import generate_entity_id
 
@@ -62,7 +68,8 @@ class AlertSensor(CoordinatorEntity, BinarySensorEntity):
     ) -> None:
         """Construct."""
         # Enable experimental settings from the configuration file
-        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+        experimental = coordinator.hass.data[DOMAIN].get(CONF_EXPERIMENTAL, {})
+        self._attr_force_update = experimental.get(CONF_FORCE_UPDATE, False)
 
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)
@@ -117,7 +124,8 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     ) -> None:
         """Construct."""
         # Enable experimental settings from the configuration file
-        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+        experimental = coordinator.hass.data[DOMAIN].get(CONF_EXPERIMENTAL, {})
+        self._attr_force_update = experimental.get(CONF_FORCE_UPDATE, False)
 
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)
@@ -163,7 +171,8 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
     ) -> None:
         """Construct."""
         # Enable experimental settings from the configuration file
-        self._attr_force_update = coordinator.hass.data[DOMAIN].get("force_update", False)
+        experimental = coordinator.hass.data[DOMAIN].get(CONF_EXPERIMENTAL, {})
+        self._attr_force_update = experimental.get(CONF_FORCE_UPDATE, False)
 
         super().__init__(coordinator)
         self.entity_id = generate_entity_id(config, name)

--- a/custom_components/econnect_metronet/const.py
+++ b/custom_components/econnect_metronet/const.py
@@ -20,3 +20,7 @@ KEY_UNSUBSCRIBER = "options_unsubscriber"
 # Fast scanning is required for real-time updates of the alarm state.
 SCAN_INTERVAL_DEFAULT = 5
 POLLING_TIMEOUT = 20
+
+# Experimental Settings
+CONF_EXPERIMENTAL = "experimental"
+CONF_FORCE_UPDATE = "force_update"

--- a/tests/test_experimental_settings.py
+++ b/tests/test_experimental_settings.py
@@ -2,7 +2,7 @@ from custom_components.econnect_metronet.binary_sensor import AlertSensor
 from custom_components.econnect_metronet.const import DOMAIN
 
 
-class TestExperiments:
+class TestExperimentalSettings:
     def test_sensor_force_update_default(self, coordinator, config_entry, alarm_device):
         # Ensure the default is to not force any update
         entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
@@ -10,6 +10,10 @@ class TestExperiments:
 
     def test_sensor_force_update_on(self, hass, coordinator, config_entry, alarm_device):
         # Ensure you can force the entity update
-        hass.data[DOMAIN] = {"force_update": True}
+        hass.data[DOMAIN] = {
+            "experimental": {
+                "force_update": True,
+            }
+        }
         entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity._attr_force_update is True


### PR DESCRIPTION
### Related Issues

- Follow-up for #85 

### Proposed Changes:

Update the experimental configuration under `experimental` key.

### Testing:

```yaml
econnect_metronet:
    experimental:
        force_update: true
```

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
