### PR TITLE
feat: create InputSensors with _inventory

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -40,9 +40,10 @@ async def async_setup_entry(
         unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{sector_id}"
         sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device))
 
-    for sensor_id, name in inventory[query.INPUTS].items():
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{sensor_id}"
-        sensors.append(InputSensor(unique_id, sensor_id, entry, name, coordinator, device))
+    # Iterate through the inputs of the provided device and create InputSensor objects
+    for input_id, name in device.inputs:
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{input_id}"
+        sensors.append(InputSensor(unique_id, input_id, entry, name, coordinator, device))
 
     # Iterate through the alerts of the provided device and create AlertSensor objects
     for alert_id, name in device.alerts:
@@ -116,7 +117,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     def __init__(
         self,
         unique_id: str,
-        sensor_id: int,
+        input_id: int,
         config: ConfigEntry,
         name: str,
         coordinator: DataUpdateCoordinator,
@@ -132,7 +133,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         self._name = name
         self._device = device
         self._unique_id = unique_id
-        self._sensor_id = sensor_id
+        self._input_id = input_id
 
     @property
     def unique_id(self) -> str:
@@ -152,7 +153,8 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        return self._device.inputs_alerted.get(self._sensor_id) is not None
+        # return self._device.inputs_alerted.get(self._sensor_id) is not None
+        return bool(self._device.get_status(query.INPUTS, self._input_id))
 
 
 class SectorSensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -56,8 +56,6 @@ class AlarmDevice:
         self.state = STATE_UNAVAILABLE
         self.sectors_armed = {}
         self.sectors_disarmed = {}
-        self.inputs_alerted = {}
-        self.inputs_wait = {}
         self._inventory = {}
 
     @property
@@ -250,11 +248,9 @@ class AlarmDevice:
         self._inventory.update({q.INPUTS: inputs["inputs"]})
         self._inventory.update({q.ALERTS: alerts})
 
-        # Filter sectors and inputs
+        # Filter sectors
         self.sectors_armed = _filter_data(sectors, "sectors", True)
         self.sectors_disarmed = _filter_data(sectors, "sectors", False)
-        self.inputs_alerted = _filter_data(inputs, "inputs", True)
-        self.inputs_wait = _filter_data(inputs, "inputs", False)
 
         self._last_ids[q.SECTORS] = sectors.get("last_id", 0)
         self._last_ids[q.INPUTS] = inputs.get("last_id", 0)

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -119,7 +119,7 @@ class TestInputSensor:
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
-        alarm_device.inputs_alerted.update({entity._sensor_id: {}})
+        # alarm_device.inputs_alerted.update({entity._sensor_id: {}})
         assert entity.is_on is True
 
 

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -119,7 +119,6 @@ class TestInputSensor:
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
-        # alarm_device.inputs_alerted.update({entity._sensor_id: {}})
         assert entity.is_on is True
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -33,8 +33,6 @@ def test_device_constructor(client):
     assert device.state == STATE_UNAVAILABLE
     assert device.sectors_armed == {}
     assert device.sectors_disarmed == {}
-    assert device.inputs_alerted == {}
-    assert device.inputs_wait == {}
 
 
 def test_device_constructor_with_config(client):
@@ -55,8 +53,6 @@ def test_device_constructor_with_config(client):
     assert device.state == STATE_UNAVAILABLE
     assert device.sectors_armed == {}
     assert device.sectors_disarmed == {}
-    assert device.inputs_alerted == {}
-    assert device.inputs_wait == {}
 
 
 class TestItemInputs:
@@ -300,21 +296,12 @@ def test_device_update_success(client, mocker):
     sectors_disarmed = {
         2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": False, "name": "S3 Outdoor"}
     }
-    inputs_alerted = {
-        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "Entryway Sensor"},
-        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "Outdoor Sensor 1"},
-    }
-    inputs_wait = {
-        2: {"id": 3, "index": 2, "element": 3, "excluded": True, "status": False, "name": "Outdoor Sensor 2"}
-    }
     device.connect("username", "password")
     # Test
     device.update()
     assert device._connection.query.call_count == 3
     assert device.sectors_armed == sectors_armed
     assert device.sectors_disarmed == sectors_disarmed
-    assert device.inputs_alerted == inputs_alerted
-    assert device.inputs_wait == inputs_wait
     assert device._last_ids == {
         9: 4,
         10: 42,
@@ -452,19 +439,40 @@ class TestAlertsView:
         assert dict(alarm_device.alerts) == alerts
 
     def test_inventory_empty(self, alarm_device):
-        """Ensure the property returns an empty dict if _inventory is empty"""
+        """Ensure the property returns a KeyError if _inventory is empty"""
         # Test
         alarm_device._inventory = {}
         assert dict(alarm_device.alerts) == {}
 
     def test_alerts_property_empty(self, alarm_device):
-        """Ensure the property returns an empty dict if alerts key is not in _inventory"""
+        """Ensure the property returns a KeyError if alerts key is not in _inventory"""
         # Test
         alarm_device._inventory = {"alerts": {}}
         assert dict(alarm_device.alerts) == {}
 
 
-class TestGetStatus:
+class TestGetStatusInputs:
+    def test_get_status_populated(self, alarm_device):
+        """Should check if the device property is correctly populated"""
+        # Test
+        assert alarm_device.get_status(q.INPUTS, 2) is False
+
+    def test_inventory_empty(self, alarm_device):
+        """Ensure the property returns a KeyError if _inventory is empty"""
+        # Test
+        alarm_device._inventory = {}
+        with pytest.raises(KeyError):
+            assert alarm_device.get_status(q.INPUTS, 2)
+
+    def test_alerts_property_empty(self, alarm_device):
+        """Ensure the property returns a KeyError if inputs key is not in _inventory"""
+        # Test
+        alarm_device._inventory = {10: {}}
+        with pytest.raises(KeyError):
+            assert alarm_device.get_status(q.INPUTS, 2)
+
+
+class TestGetStatusAlerts:
     def test_get_status_populated(self, alarm_device):
         """Should check if the device property is correctly populated"""
         # Test


### PR DESCRIPTION
### Related Issues


### Proposed Changes:
Create InputSensors from _inventory query and use new get_status function for rendering the is_on state

### Testing:


### Extra Notes (optional):


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
