### PR TITLE
feat: create InputSensors with _inventory

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -40,9 +40,10 @@ async def async_setup_entry(
         unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{sector_id}"
         sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device))
 
-    for sensor_id, name in inventory[query.INPUTS].items():
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{sensor_id}"
-        sensors.append(InputSensor(unique_id, sensor_id, entry, name, coordinator, device))
+    # Iterate through the inputs of the provided device and create InputSensor objects
+    for input_id, name in device.inputs:
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{input_id}"
+        sensors.append(InputSensor(unique_id, input_id, entry, name, coordinator, device))
 
     # Iterate through the alerts of the provided device and create AlertSensor objects
     for alert_id, name in device.alerts:
@@ -116,7 +117,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     def __init__(
         self,
         unique_id: str,
-        sensor_id: int,
+        input_id: int,
         config: ConfigEntry,
         name: str,
         coordinator: DataUpdateCoordinator,
@@ -132,7 +133,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         self._name = name
         self._device = device
         self._unique_id = unique_id
-        self._sensor_id = sensor_id
+        self._input_id = input_id
 
     @property
     def unique_id(self) -> str:
@@ -152,7 +153,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        return self._device.inputs_alerted.get(self._sensor_id) is not None
+        return bool(self._device.get_status(query.INPUTS, self._input_id))
 
 
 class SectorSensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -56,8 +56,6 @@ class AlarmDevice:
         self.state = STATE_UNAVAILABLE
         self.sectors_armed = {}
         self.sectors_disarmed = {}
-        self.inputs_alerted = {}
-        self.inputs_wait = {}
         self._inventory = {}
 
     @property
@@ -250,11 +248,9 @@ class AlarmDevice:
         self._inventory.update({q.INPUTS: inputs["inputs"]})
         self._inventory.update({q.ALERTS: alerts})
 
-        # Filter sectors and inputs
+        # Filter sectors
         self.sectors_armed = _filter_data(sectors, "sectors", True)
         self.sectors_disarmed = _filter_data(sectors, "sectors", False)
-        self.inputs_alerted = _filter_data(inputs, "inputs", True)
-        self.inputs_wait = _filter_data(inputs, "inputs", False)
 
         self._last_ids[q.SECTORS] = sectors.get("last_id", 0)
         self._last_ids[q.INPUTS] = inputs.get("last_id", 0)

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -119,7 +119,6 @@ class TestInputSensor:
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputSensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
-        alarm_device.inputs_alerted.update({entity._sensor_id: {}})
         assert entity.is_on is True
 
 


### PR DESCRIPTION
### Related Issues


### Proposed Changes:
Create InputSensors from _inventory query and use new get_status function for rendering the is_on state

### Testing:


### Extra Notes (optional):


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
