### PR TITLE
feat: create SectorSensors with _inventory

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -1,5 +1,5 @@
 """Module for e-connect binary sensors (sectors, inputs and alert)."""
-from elmo import query
+from elmo import query as q
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -33,21 +33,22 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
     # Load all entities and register sectors and inputs
     # TODO: use a public API (change in econnect-python)
-    # TODO: check why I can't use directly the device (maybe it's not loaded at this time)
+
     sensors = []
-    inventory = await hass.async_add_executor_job(device._connection._get_descriptions)
-    for sector_id, name in inventory[query.SECTORS].items():
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.SECTORS}_{sector_id}"
+
+    # Iterate through the sectors of the provided device and create InputSensor objects
+    for sector_id, name in device.sectors:
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{q.SECTORS}_{sector_id}"
         sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device))
 
     # Iterate through the inputs of the provided device and create InputSensor objects
     for input_id, name in device.inputs:
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.INPUTS}_{input_id}"
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{q.INPUTS}_{input_id}"
         sensors.append(InputSensor(unique_id, input_id, entry, name, coordinator, device))
 
     # Iterate through the alerts of the provided device and create AlertSensor objects
     for alert_id, name in device.alerts:
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{query.ALERTS}_{alert_id}"
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{q.ALERTS}_{alert_id}"
         sensors.append(AlertSensor(unique_id, alert_id, entry, name, coordinator, device))
 
     async_add_entities(sensors)
@@ -102,7 +103,7 @@ class AlertSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        status = self._device.get_status(query.ALERTS, self._alert_id)
+        status = self._device.get_status(q.ALERTS, self._alert_id)
         if self._name == "anomalies_led":
             return status > 1
         else:
@@ -153,7 +154,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        return bool(self._device.get_status(query.INPUTS, self._input_id))
+        return bool(self._device.get_status(q.INPUTS, self._input_id))
 
 
 class SectorSensor(CoordinatorEntity, BinarySensorEntity):
@@ -200,4 +201,4 @@ class SectorSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the binary sensor status (on/off)."""
-        return self._device.sectors_armed.get(self._sector_id) is not None
+        return bool(self._device.get_status(q.SECTORS, self._sector_id))

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -152,7 +152,7 @@ class TestSectorSensor:
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = SectorSensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.icon == "hass:shield-home-outline"
 
     def test_binary_sensor_off(self, hass, config_entry, alarm_device):
@@ -164,6 +164,5 @@ class TestSectorSensor:
     def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
-        alarm_device.sectors_armed.update({entity._sector_id: {}})
+        entity = SectorSensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.is_on is True

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -31,8 +31,6 @@ def test_device_constructor(client):
     assert device._sectors_night == []
     assert device._sectors_vacation == []
     assert device.state == STATE_UNAVAILABLE
-    assert device.sectors_armed == {}
-    assert device.sectors_disarmed == {}
 
 
 def test_device_constructor_with_config(client):
@@ -51,8 +49,6 @@ def test_device_constructor_with_config(client):
     assert device._sectors_night == [1, 2, 3]
     assert device._sectors_vacation == [5, 3]
     assert device.state == STATE_UNAVAILABLE
-    assert device.sectors_armed == {}
-    assert device.sectors_disarmed == {}
 
 
 class TestItemInputs:
@@ -289,19 +285,10 @@ def test_device_update_success(client, mocker):
     """Should check store the e-connect System status in the device object."""
     device = AlarmDevice(client)
     mocker.spy(device._connection, "query")
-    sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
-    }
-    sectors_disarmed = {
-        2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": False, "name": "S3 Outdoor"}
-    }
     device.connect("username", "password")
     # Test
     device.update()
     assert device._connection.query.call_count == 3
-    assert device.sectors_armed == sectors_armed
-    assert device.sectors_disarmed == sectors_disarmed
     assert device._last_ids == {
         9: 4,
         10: 42,
@@ -470,6 +457,27 @@ class TestGetStatusInputs:
         alarm_device._inventory = {10: {}}
         with pytest.raises(KeyError):
             assert alarm_device.get_status(q.INPUTS, 2)
+
+
+class TestGetStatusSectors:
+    def test_get_status_populated(self, alarm_device):
+        """Should check if the device property is correctly populated"""
+        # Test
+        assert alarm_device.get_status(q.SECTORS, 2) is False
+
+    def test_inventory_empty(self, alarm_device):
+        """Ensure the property returns a KeyError if _inventory is empty"""
+        # Test
+        alarm_device._inventory = {}
+        with pytest.raises(KeyError):
+            assert alarm_device.get_status(q.SECTORS, 2)
+
+    def test_alerts_property_empty(self, alarm_device):
+        """Ensure the property returns a KeyError if sectors key is not in _inventory"""
+        # Test
+        alarm_device._inventory = {9: {}}
+        with pytest.raises(KeyError):
+            assert alarm_device.get_status(q.SECTORS, 2)
 
 
 class TestGetStatusAlerts:
@@ -748,119 +756,126 @@ def test_device_disarm_code_error(client, mocker):
     assert device._connection.disarm.call_count == 0
 
 
-def test_get_state_no_sectors_armed(client):
+def test_get_state_no_sectors_armed(alarm_device):
     """Test when no sectors are armed."""
-    device = AlarmDevice(client)
-    device._sectors_home = []
-    device._sectors_night = []
-    device.sectors_armed = {}
+    alarm_device._sectors_home = []
+    alarm_device._sectors_night = []
+    alarm_device._inventory = {9: {}}
     # Test
-    assert device.get_state() == STATE_ALARM_DISARMED
+    assert alarm_device.get_state() == STATE_ALARM_DISARMED
 
 
-def test_get_state_armed_home(client):
+def test_get_state_armed_home(alarm_device):
     """Test when sectors are armed for home."""
-    device = AlarmDevice(client)
-    device._sectors_home = [1, 2, 3]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_home = [1, 2, 3]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_HOME
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_HOME
 
 
-def test_get_state_armed_home_out_of_order(client):
+def test_get_state_armed_home_out_of_order(alarm_device):
     """Test when sectors are armed for home (out of order)."""
-    device = AlarmDevice(client)
-    device._sectors_home = [2, 1, 3]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 3, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 1, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 2, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_home = [2, 1, 3]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 3, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 1, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 2, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_HOME
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_HOME
 
 
-def test_get_state_armed_night(client):
+def test_get_state_armed_night(alarm_device):
     """Test when sectors are armed for night."""
-    device = AlarmDevice(client)
-    device._sectors_night = [4, 5, 6]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 4, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 5, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 6, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_night = [4, 5, 6]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 4, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 5, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 6, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test (out of order keys to test sorting)
-    assert device.get_state() == STATE_ALARM_ARMED_NIGHT
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_NIGHT
 
 
-def test_get_state_armed_night_out_of_order(client):
+def test_get_state_armed_night_out_of_order(alarm_device):
     """Test when sectors are armed for night (out of order)."""
-    device = AlarmDevice(client)
-    device._sectors_night = [5, 6, 4]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 6, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 4, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 5, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_night = [5, 6, 4]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 6, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 4, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 5, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_NIGHT
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_NIGHT
 
 
-def test_get_state_armed_vacation(client):
+def test_get_state_armed_vacation(alarm_device):
     """Test when sectors are armed for vacation."""
-    device = AlarmDevice(client)
-    device._sectors_vacation = [4, 5, 6]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 4, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 5, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 6, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_vacation = [4, 5, 6]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 4, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 5, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 6, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test (out of order keys to test sorting)
-    assert device.get_state() == STATE_ALARM_ARMED_VACATION
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_VACATION
 
 
-def test_get_state_armed_vacation_out_of_order(client):
+def test_get_state_armed_vacation_out_of_order(alarm_device):
     """Test when sectors are armed for vacation (out of order)."""
-    device = AlarmDevice(client)
-    device._sectors_vacation = [5, 6, 4]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 6, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 4, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 5, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_vacation = [5, 6, 4]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 6, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 4, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 5, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_VACATION
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_VACATION
 
 
-def test_get_state_armed_away(client):
+def test_get_state_armed_away(alarm_device):
     """Test when sectors are armed but don't match home or night."""
-    device = AlarmDevice(client)
-    device._sectors_home = [1, 2, 3]
-    device._sectors_night = [4, 5, 6]
-    device._sectors_vacation = [4, 2]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 4, "excluded": False, "status": True, "name": "S3 Outdoor"},
+    alarm_device._sectors_home = [1, 2, 3]
+    alarm_device._sectors_night = [4, 5, 6]
+    alarm_device._sectors_vacation = [4, 2]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 4, "excluded": False, "status": True, "name": "S3 Outdoor"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_AWAY
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY
 
 
-def test_get_state_armed_mixed(client):
+def test_get_state_armed_mixed(alarm_device):
     """Test when some sectors from home and night are armed."""
-    device = AlarmDevice(client)
-    device._sectors_home = [1, 2, 3]
-    device._sectors_night = [4, 5, 6]
-    device.sectors_armed = {
-        0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
-        1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
-        2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": True, "name": "S3 Outdoor"},
-        3: {"id": 4, "index": 3, "element": 5, "excluded": False, "status": True, "name": "S5 Perimeter"},
+    alarm_device._sectors_home = [1, 2, 3]
+    alarm_device._sectors_night = [4, 5, 6]
+    alarm_device._inventory = {
+        9: {
+            0: {"id": 1, "index": 0, "element": 1, "excluded": False, "status": True, "name": "S1 Living Room"},
+            1: {"id": 2, "index": 1, "element": 2, "excluded": False, "status": True, "name": "S2 Bedroom"},
+            2: {"id": 3, "index": 2, "element": 3, "excluded": False, "status": True, "name": "S3 Outdoor"},
+            3: {"id": 4, "index": 3, "element": 5, "excluded": False, "status": True, "name": "S5 Perimeter"},
+        }
     }
     # Test
-    assert device.get_state() == STATE_ALARM_ARMED_AWAY
+    assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY


### PR DESCRIPTION
### Related Issues

- Closes #59 

### Proposed Changes:
Create SectorSensors from _inventory query and use new get_status function for rendering the is_on state

### Testing:


### Extra Notes (optional):
Now the integration create only binary sensors for sectors that are configured in control panel

Screenshoot of binary sensors with original code:
![after](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/f30449e0-508e-4a25-8eb4-208a1088bffc)

Screenshoot of binary sensors with modified code:
![before](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/327fd588-7691-4bab-9611-9322567eec9f)

### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
