### PR TITLE
fix: restore previous unique id structure in `AlertSensor`

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
 
     # Iterate through the alerts of the provided device and create AlertSensor objects
     for alert_id, name in device.alerts:
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{q.ALERTS}_{alert_id}"
+        unique_id = f"{entry.entry_id}_{DOMAIN}_{name}"
         sensors.append(AlertSensor(unique_id, alert_id, entry, name, coordinator, device))
 
     async_add_entities(sensors)

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -59,6 +59,21 @@ async def test_async_setup_entry_unused_sector(hass, config_entry, alarm_device,
     await async_setup_entry(hass, config_entry, ensure_unused_sectors)
 
 
+@pytest.mark.asyncio
+async def test_async_setup_entry_alerts_unique_id(hass, config_entry, alarm_device, coordinator):
+    # Regression test: changing this unique ID format is a breaking change
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+
+    # Test
+    def ensure_unused_sectors(sensors):
+        assert sensors[30].unique_id == "test_entry_id_econnect_metronet_tamper_led"
+
+    await async_setup_entry(hass, config_entry, ensure_unused_sectors)
+
+
 class TestAlertSensor:
     def test_binary_sensor_is_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True


### PR DESCRIPTION
### Related Issues


### Proposed Changes:
Change how is generated the uniqueID for Alerts and revert to old method for backward compatibility

### Testing:


### Extra Notes (optional):


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
