### PR TITLE
fix: read alerts last ids for polling

### DIFF
--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -43,6 +43,7 @@ class AlarmDevice:
         self._last_ids = {
             q.SECTORS: 0,
             q.INPUTS: 0,
+            q.ALERTS: 0,
         }
 
         # Load user configuration
@@ -240,11 +241,12 @@ class AlarmDevice:
         # Update the _inventory
         self._inventory.update({q.SECTORS: sectors["sectors"]})
         self._inventory.update({q.INPUTS: inputs["inputs"]})
-        self._inventory.update({q.ALERTS: alerts})
+        self._inventory.update({q.ALERTS: alerts["alerts"]})
 
         # Update the _last_ids
         self._last_ids[q.SECTORS] = sectors.get("last_id", 0)
         self._last_ids[q.INPUTS] = inputs.get("last_id", 0)
+        self._last_ids[q.ALERTS] = alerts.get("last_id", 0)
 
         # Update the internal state machine (mapping state)
         self.state = self.get_state()

--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -15,7 +15,7 @@
     "custom_components.econnect_metronet"
   ],
   "requirements": [
-    "econnect-python==0.8.0"
+    "econnect-python==0.8.1"
   ],
   "version": "2.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.8.0",
+  "econnect-python==0.8.1",
   "homeassistant",
 ]
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -26,7 +26,7 @@ def test_device_constructor(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
-    assert device._last_ids == {10: 0, 9: 0}
+    assert device._last_ids == {10: 0, 9: 0, 11: 0}
     assert device._sectors_home == []
     assert device._sectors_night == []
     assert device._sectors_vacation == []
@@ -44,7 +44,7 @@ def test_device_constructor_with_config(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
-    assert device._last_ids == {10: 0, 9: 0}
+    assert device._last_ids == {10: 0, 9: 0, 11: 0}
     assert device._sectors_home == [3, 4]
     assert device._sectors_night == [1, 2, 3]
     assert device._sectors_vacation == [5, 3]
@@ -230,11 +230,12 @@ def test_device_has_updates(client, mocker):
     device.connect("username", "password")
     device._last_ids[q.SECTORS] = 20
     device._last_ids[q.INPUTS] = 20
+    device._last_ids[q.ALERTS] = 20
     mocker.spy(device._connection, "poll")
     # Test
     device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 20, 10: 20} in device._connection.poll.call_args[0]
+    assert {9: 20, 10: 20, 11: 20} in device._connection.poll.call_args[0]
 
 
 def test_device_has_updates_ids_immutable(client, mocker):
@@ -265,7 +266,7 @@ def test_device_has_updates_errors(client, mocker):
     with pytest.raises(HTTPError):
         device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 0, 10: 0} == device._last_ids
+    assert {9: 0, 10: 0, 11: 0} == device._last_ids
 
 
 def test_device_has_updates_parse_errors(client, mocker):
@@ -278,7 +279,7 @@ def test_device_has_updates_parse_errors(client, mocker):
     with pytest.raises(ParseError):
         device.has_updates()
     assert device._connection.poll.call_count == 1
-    assert {9: 0, 10: 0} == device._last_ids
+    assert {9: 0, 10: 0, 11: 0} == device._last_ids
 
 
 def test_device_update_success(client, mocker):
@@ -292,6 +293,7 @@ def test_device_update_success(client, mocker):
     assert device._last_ids == {
         9: 4,
         10: 42,
+        11: 1,
     }
 
 


### PR DESCRIPTION
### Related Issues

### Proposed Changes:
Implement the functionality to read and store the latest alert IDs for efficiently polling updates

### Testing:


### Extra Notes (optional):


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
