### PR TITLE
feat!: treat alarm_led, tamper_led and inputs_led as sensors

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -22,7 +22,7 @@ from .devices import AlarmDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["alarm_control_panel", "binary_sensor"]
+PLATFORMS = ["alarm_control_panel", "binary_sensor", "sensor"]
 
 
 async def async_migrate_entry(hass, config: ConfigEntry):

--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
         sensors.append(InputBinarySensor(unique_id, input_id, entry, name, coordinator, device))
 
     # Iterate through the alerts of the provided device and create AlertBinarySensor objects
-    # except for alarm_led, inputs_led and tamper_led
+    # except for alarm_led, inputs_led and tamper_led as they have three states
     for alert_id, name in device.alerts:
         if name not in ["alarm_led", "inputs_led", "tamper_led"]:
             unique_id = f"{entry.entry_id}_{DOMAIN}_{name}"

--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -35,25 +35,27 @@ async def async_setup_entry(
 
     sensors = []
 
-    # Iterate through the sectors of the provided device and create InputSensor objects
+    # Iterate through the sectors of the provided device and create InputBinarySensor objects
     for sector_id, name in device.sectors:
         unique_id = f"{entry.entry_id}_{DOMAIN}_{q.SECTORS}_{sector_id}"
-        sensors.append(SectorSensor(unique_id, sector_id, entry, name, coordinator, device))
+        sensors.append(SectorBinarySensor(unique_id, sector_id, entry, name, coordinator, device))
 
-    # Iterate through the inputs of the provided device and create InputSensor objects
+    # Iterate through the inputs of the provided device and create InputBinarySensor objects
     for input_id, name in device.inputs:
         unique_id = f"{entry.entry_id}_{DOMAIN}_{q.INPUTS}_{input_id}"
-        sensors.append(InputSensor(unique_id, input_id, entry, name, coordinator, device))
+        sensors.append(InputBinarySensor(unique_id, input_id, entry, name, coordinator, device))
 
-    # Iterate through the alerts of the provided device and create AlertSensor objects
+    # Iterate through the alerts of the provided device and create AlertBinarySensor objects
+    # except for alarm_led, inputs_led and tamper_led
     for alert_id, name in device.alerts:
-        unique_id = f"{entry.entry_id}_{DOMAIN}_{name}"
-        sensors.append(AlertSensor(unique_id, alert_id, entry, name, coordinator, device))
+        if name not in ["alarm_led", "inputs_led", "tamper_led"]:
+            unique_id = f"{entry.entry_id}_{DOMAIN}_{name}"
+            sensors.append(AlertBinarySensor(unique_id, alert_id, entry, name, coordinator, device))
 
     async_add_entities(sensors)
 
 
-class AlertSensor(CoordinatorEntity, BinarySensorEntity):
+class AlertBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a e-Connect alert binary sensor"""
 
     _attr_has_entity_name = True
@@ -109,7 +111,7 @@ class AlertSensor(CoordinatorEntity, BinarySensorEntity):
             return bool(status)
 
 
-class InputSensor(CoordinatorEntity, BinarySensorEntity):
+class InputBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a e-connect input binary sensor."""
 
     _attr_has_entity_name = True
@@ -156,7 +158,7 @@ class InputSensor(CoordinatorEntity, BinarySensorEntity):
         return bool(self._device.get_status(q.INPUTS, self._input_id))
 
 
-class SectorSensor(CoordinatorEntity, BinarySensorEntity):
+class SectorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a e-connect sector binary sensor."""
 
     _attr_has_entity_name = True

--- a/custom_components/econnect_metronet/sensor.py
+++ b/custom_components/econnect_metronet/sensor.py
@@ -1,0 +1,88 @@
+"""Module for e-connect sensors (alert) """
+from elmo import query as q
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import (
+    CONF_EXPERIMENTAL,
+    CONF_FORCE_UPDATE,
+    DOMAIN,
+    KEY_COORDINATOR,
+    KEY_DEVICE,
+)
+from .devices import AlarmDevice
+from .helpers import generate_entity_id
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up e-connect sensors from a config entry."""
+    device = hass.data[DOMAIN][entry.entry_id][KEY_DEVICE]
+    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    # Load all entities and register sectors and inputs
+
+    sensors = []
+
+    # Iterate through the alerts of the provided device and create AlertSensor objects
+    # only for alarm_led, inputs_led and tamper_led
+    for alert_id, name in device.alerts:
+        if name in ["alarm_led", "inputs_led", "tamper_led"]:
+            unique_id = f"{entry.entry_id}_{DOMAIN}_{q.ALERTS}_{alert_id}"
+            sensors.append(AlertSensor(unique_id, alert_id, entry, name, coordinator, device))
+
+    async_add_entities(sensors)
+
+
+class AlertSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a e-Connect alert sensor"""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        unique_id: str,
+        alert_id: int,
+        config: ConfigEntry,
+        name: str,
+        coordinator: DataUpdateCoordinator,
+        device: AlarmDevice,
+    ) -> None:
+        """Construct."""
+        # Enable experimental settings from the configuration file
+        experimental = coordinator.hass.data[DOMAIN].get(CONF_EXPERIMENTAL, {})
+        self._attr_force_update = experimental.get(CONF_FORCE_UPDATE, False)
+
+        super().__init__(coordinator)
+        self.entity_id = generate_entity_id(config, name)
+        self._name = name
+        self._device = device
+        self._unique_id = unique_id
+        self._alert_id = alert_id
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique identifier."""
+        return self._unique_id
+
+    @property
+    def translation_key(self) -> str:
+        """Return the translation key to translate the entity's name and states."""
+        return self._name
+
+    @property
+    def icon(self) -> str:
+        """Return the icon used by this entity."""
+        return "hass:alarm-light"
+
+    @property
+    def native_value(self) -> int | None:
+        return self._device.get_status(q.ALERTS, self._alert_id)

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -41,30 +41,35 @@
         }
     },
     "entity": {
-        "binary_sensor": {
-            "anomalies_led": {
-                "name": "General Anomaly",
-                "state": {
-                    "on": "On",
-                    "off": "Off"
-                }
-            },
+        "sensor": {
             "inputs_led": {
                 "name": "Zones Ready Status",
                 "state": {
-                    "on": "On",
-                    "off": "Off"
+                    "0": "Not ready",
+                    "1": "Ready",
+                    "2": "Partially ready"
                 }
             },
             "alarm_led": {
                 "name": "General Alarm",
                 "state": {
-                    "on": "On",
-                    "off": "Off"
+                    "0": "No alarms",
+                    "1": "Alarm in progress",
+                    "2": "Alarm memory"
                 }
             },
             "tamper_led": {
                 "name": "General Tamper",
+                "state": {
+                    "0": "No tampers",
+                    "1": "Tamper in progress",
+                    "2": "Tamper memory"
+                }
+            }
+        },
+        "binary_sensor": {
+            "anomalies_led": {
+                "name": "General Anomaly",
                 "state": {
                     "on": "On",
                     "off": "Off"

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -41,30 +41,35 @@
         }
     },
     "entity": {
-        "binary_sensor": {
-            "anomalies_led": {
-                "name": "Anomalia Generale",
-                "state": {
-                    "on": "On",
-                    "off": "Off"
-                }
-            },
+        "sensor": {
             "inputs_led": {
                 "name": "Stato Inseribilità Zone",
                 "state": {
-                    "on": "On",
-                    "off": "Off"
+                    "0": "Non pronto",
+                    "1": "Pronto",
+                    "2": "Parzialmente pronto"
                 }
             },
             "alarm_led": {
                 "name": "Allarme Generale",
                 "state": {
-                    "on": "On",
-                    "off": "Off"
+                    "0": "Nessun allarme",
+                    "1": "Allarme in corso",
+                    "2": "Memoria allarme"
                 }
             },
             "tamper_led": {
                 "name": "Manomissione Generale",
+                "state": {
+                    "0": "Nessuna manomissione",
+                    "1": "Manomissione in corso",
+                    "2": "Memoria manomissione"
+                }
+            }
+        },
+        "binary_sensor": {
+            "anomalies_led": {
+                "name": "Anomalia Generale",
                 "state": {
                     "on": "On",
                     "off": "Off"

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -4,9 +4,9 @@ import pytest
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet.binary_sensor import (
-    AlertSensor,
-    InputSensor,
-    SectorSensor,
+    AlertBinarySensor,
+    InputBinarySensor,
+    SectorBinarySensor,
     async_setup_entry,
 )
 from custom_components.econnect_metronet.const import DOMAIN
@@ -22,25 +22,25 @@ async def test_async_setup_entry_in_use(hass, config_entry, alarm_device, coordi
 
     # Test
     def ensure_only_in_use(sensors):
-        assert len(sensors) == 31
+        assert len(sensors) == 28
 
     await async_setup_entry(hass, config_entry, ensure_only_in_use)
 
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_unused_input(hass, config_entry, alarm_device, coordinator):
-    # Ensure the async setup don't load sensors that are not in use
+    # Ensure the async setup don't load inputs that are not in use
     hass.data[DOMAIN][config_entry.entry_id] = {
         "device": alarm_device,
         "coordinator": coordinator,
     }
 
     # Test
-    def ensure_unused_sensors(sensors):
+    def ensure_unused_input(sensors):
         for sensor in sensors:
             assert sensor._name not in ["Outdoor Sensor 3"]
 
-    await async_setup_entry(hass, config_entry, ensure_unused_sensors)
+    await async_setup_entry(hass, config_entry, ensure_unused_input)
 
 
 @pytest.mark.asyncio
@@ -68,189 +68,189 @@ async def test_async_setup_entry_alerts_unique_id(hass, config_entry, alarm_devi
     }
 
     # Test
-    def ensure_unused_sectors(sensors):
-        assert sensors[30].unique_id == "test_entry_id_econnect_metronet_tamper_led"
+    def ensure_unique_id(sensors):
+        assert sensors[27].unique_id == "test_entry_id_econnect_metronet_system_test"
 
-    await async_setup_entry(hass, config_entry, ensure_unused_sectors)
+    await async_setup_entry(hass, config_entry, ensure_unique_id)
 
 
-class TestAlertSensor:
+class TestAlertBinarySensor:
     def test_binary_sensor_is_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
+        entity = AlertBinarySensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity.is_on is True
 
     def test_binary_sensor_is_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("device_failure", 2, config_entry, "device_failure", coordinator, alarm_device)
+        entity = AlertBinarySensor("device_failure", 2, config_entry, "device_failure", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_missing(self, hass, config_entry, alarm_device):
-        # Ensure the sensor attribute is_on has the right status False if the alert is missing
+        # Ensure the sensor raise keyerror if the alert is missing
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
         with pytest.raises(KeyError):
             assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
+        entity = AlertBinarySensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         alarm_device._inventory[11][1]["status"] = 2
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
+        entity = AlertBinarySensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is True
 
     def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right translation key
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
     def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
     def test_binary_sensor_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right unique ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.icon == "hass:alarm-light"
 
     def test_binary_sensor_device_class(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right device class
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = AlertSensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
+        entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.device_class == "problem"
 
 
-class TestInputSensor:
+class TestInputBinarySensor:
     def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
 
     def test_binary_sensor_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right unique ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:electric-switch"
 
     def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 2, config_entry, "Outdoor Sensor 2", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 2, config_entry, "Outdoor Sensor 2", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = InputSensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
+        entity = InputBinarySensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
         assert entity.is_on is True
 
 
-class TestSectorSensor:
+class TestSectorBinarySensor:
     def test_binary_sensor_input_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
     def test_binary_sensor_input_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         config_entry.data["system_name"] = "Home"
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"
 
     def test_binary_sensor_input_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right unique ID
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.icon == "hass:shield-home-outline"
 
     def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-        entity = SectorSensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
+        entity = SectorBinarySensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.is_on is True

--- a/tests/test_experimental_settings.py
+++ b/tests/test_experimental_settings.py
@@ -1,11 +1,11 @@
-from custom_components.econnect_metronet.binary_sensor import AlertSensor
+from custom_components.econnect_metronet.binary_sensor import AlertBinarySensor
 from custom_components.econnect_metronet.const import DOMAIN
 
 
 class TestExperimentalSettings:
     def test_sensor_force_update_default(self, coordinator, config_entry, alarm_device):
         # Ensure the default is to not force any update
-        entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
+        entity = AlertBinarySensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity._attr_force_update is False
 
     def test_sensor_force_update_on(self, hass, coordinator, config_entry, alarm_device):
@@ -15,5 +15,5 @@ class TestExperimentalSettings:
                 "force_update": True,
             }
         }
-        entity = AlertSensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
+        entity = AlertBinarySensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity._attr_force_update is True

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,90 @@
+import logging
+
+import pytest
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.econnect_metronet.const import DOMAIN
+from custom_components.econnect_metronet.sensor import AlertSensor, async_setup_entry
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_only_sensors(hass, config_entry, alarm_device, coordinator):
+    # Ensure the async setup loads only alert sensors
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+
+    # Test
+    def ensure_only_sensors(sensors):
+        assert len(sensors) == 3
+
+    await async_setup_entry(hass, config_entry, ensure_only_sensors)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_alerts_unique_id(hass, config_entry, alarm_device, coordinator):
+    # Ensure that the alert sensors have the correct unique IDs
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+
+    # Test
+    def ensure_unique_id(sensors):
+        assert sensors[1].unique_id == "test_entry_id_econnect_metronet_11_16"
+
+    await async_setup_entry(hass, config_entry, ensure_unique_id)
+
+
+class TestAlertSensor:
+    def test_sensor_native_value(self, hass, config_entry, alarm_device):
+        # Ensure the sensor attribute native_value has the right status
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 16, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.native_value == 2
+
+    def test_sensor_missing(self, hass, config_entry, alarm_device):
+        # Ensure the sensor raise keyerror if the alert is missing
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
+        with pytest.raises(KeyError):
+            assert entity.native_value == 1
+
+    def test_sensor_name(self, hass, config_entry, alarm_device):
+        # Ensure the alert has the right translation key
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 16, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.translation_key == "input_led"
+
+    def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
+        # The system name doesn't change the translation key
+        config_entry.data["system_name"] = "Home"
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.translation_key == "input_led"
+
+    def test_sensor_entity_id(self, hass, config_entry, alarm_device):
+        # Ensure the alert has a valid Entity ID
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_input_led"
+
+    def test_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
+        # Ensure the Entity ID takes into consideration the system name
+        config_entry.data["system_name"] = "Home"
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.entity_id == "econnect_metronet.econnect_metronet_home_input_led"
+
+    def test_sensor_unique_id(self, hass, config_entry, alarm_device):
+        # Ensure the alert has the right unique ID
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.unique_id == "test_id"
+
+    def test_sensor_icon(self, hass, config_entry, alarm_device):
+        # Ensure the sensor has the right icon
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
+        assert entity.icon == "hass:alarm-light"


### PR DESCRIPTION
### Related Issues

- Closes #81 

### Proposed Changes:
Transform alarm_led, tamper_led and inputs_led in sensor with a text translated reported status
0: No Alarm
1: Memory Alarm
2: Alarm

Based on the original user manual specification:

![Screenshot 2023-10-28 145355](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/3221c784-06e7-4e06-a919-5e66d3620dab)

### Testing:


### Extra Notes (optional):
New sensors are rapresented like this:
![Screenshot_20231028_140950_Chrome](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/bc8bcc90-46ff-4e1b-998d-3ce2a967114a)

Individual sensor history is represented like this
![Screenshot_20231028_141007_Chrome](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/bbaa2e50-f0b0-4e13-89ea-8b68672cc190)

### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
