### PR TITLE
refactor: use multi select in setup options

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -37,6 +37,20 @@ async def async_migrate_entry(hass, config: ConfigEntry):
         config.version = 2
         hass.config_entries.async_update_entry(config, data=migrated_config)
 
+    if config.version == 2:
+        # Config initialization
+        options = {**config.options}
+        options_to_migrate = ["areas_arm_home", "areas_arm_night", "areas_arm_vacation"]
+        migrated_options = {}
+        # Migration
+        config.version = 3
+        for key, value in options.items():
+            if key in options_to_migrate:
+                migrated_options[key] = [int(area) for area in value.split(",")]
+            else:
+                migrated_options[key] = value
+        hass.config_entries.async_update_entry(config, options=migrated_options)
+
     _LOGGER.info(f"Migration to version {config.version} successful")
     return True
 

--- a/custom_components/econnect_metronet/config_flow.py
+++ b/custom_components/econnect_metronet/config_flow.py
@@ -1,6 +1,5 @@
 import logging
 
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from elmo.api.client import ElmoClient
 from elmo import query as q
@@ -9,6 +8,7 @@ from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
+from homeassistant.helpers.config_validation import multi_select
 from requests.exceptions import ConnectionError, HTTPError
 
 from .const import (
@@ -136,10 +136,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         suggest_scan_interval = user_input.get(CONF_SCAN_INTERVAL) or self.config_entry.options.get(CONF_SCAN_INTERVAL)
 
         # Generate sectors list for user config options
-        sectors_list = []
         device = self.hass.data[DOMAIN][self.config_entry.entry_id][KEY_DEVICE]
-        for sector_id, item in device._inventory.get(q.SECTORS, {}).items():
-            sectors_list.append(f"{item['element']} : {item['name']}")
+        sectors_list = {f"{item['element']} : {item['name']}" for sector_id, item in device.items(q.SECTORS)}
 
         return self.async_show_form(
             step_id="init",
@@ -148,15 +146,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_AREAS_ARM_HOME,
                         default=self.config_entry.options.get(CONF_AREAS_ARM_HOME),
-                    ): cv.multi_select(sectors_list),
+                    ): multi_select(sectors_list),
                     vol.Optional(
                         CONF_AREAS_ARM_NIGHT,
                         default=self.config_entry.options.get(CONF_AREAS_ARM_NIGHT),
-                    ): cv.multi_select(sectors_list),
+                    ): multi_select(sectors_list),
                     vol.Optional(
                         CONF_AREAS_ARM_VACATION,
                         default=self.config_entry.options.get(CONF_AREAS_ARM_VACATION),
-                    ): cv.multi_select(sectors_list),
+                    ): multi_select(sectors_list),
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
                         description={"suggested_value": suggest_scan_interval},

--- a/custom_components/econnect_metronet/config_flow.py
+++ b/custom_components/econnect_metronet/config_flow.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class EconnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Handle a config flow for E-connect Alarm."""
 
-    VERSION = 2
+    VERSION = 3
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     @staticmethod

--- a/custom_components/econnect_metronet/config_flow.py
+++ b/custom_components/econnect_metronet/config_flow.py
@@ -1,8 +1,8 @@
 import logging
 
 import voluptuous as vol
-from elmo.api.client import ElmoClient
 from elmo import query as q
+from elmo.api.client import ElmoClient
 from elmo.api.exceptions import CredentialError
 from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
 from homeassistant import config_entries

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -47,9 +47,9 @@ class AlarmDevice:
 
         # Load user configuration
         if config is not None:
-            self._sectors_home = config.get(CONF_AREAS_ARM_HOME)
-            self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT)
-            self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION)
+            self._sectors_home = config.get(CONF_AREAS_ARM_HOME, [])
+            self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT, [])
+            self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION, [])
 
         # Alarm state
         self.state = STATE_UNAVAILABLE

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
 from requests.exceptions import HTTPError
 
 from .const import CONF_AREAS_ARM_HOME, CONF_AREAS_ARM_NIGHT, CONF_AREAS_ARM_VACATION
-from .helpers import parse_areas_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,9 +47,9 @@ class AlarmDevice:
 
         # Load user configuration
         if config is not None:
-            self._sectors_home = parse_areas_config(config.get(CONF_AREAS_ARM_HOME))
-            self._sectors_night = parse_areas_config(config.get(CONF_AREAS_ARM_NIGHT))
-            self._sectors_vacation = parse_areas_config(config.get(CONF_AREAS_ARM_VACATION))
+            self._sectors_home = config.get(CONF_AREAS_ARM_HOME)
+            self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT)
+            self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION)
 
         # Alarm state
         self.state = STATE_UNAVAILABLE

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -35,10 +35,8 @@ class AlarmDevice:
 
     def __init__(self, connection, config=None):
         # Configuration and internals
+        self._inventory = {}
         self._connection = connection
-        self._sectors_home = []
-        self._sectors_night = []
-        self._sectors_vacation = []
         self._last_ids = {
             q.SECTORS: 0,
             q.INPUTS: 0,
@@ -46,14 +44,13 @@ class AlarmDevice:
         }
 
         # Load user configuration
-        if config is not None:
-            self._sectors_home = config.get(CONF_AREAS_ARM_HOME, [])
-            self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT, [])
-            self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION, [])
+        config = config or {}
+        self._sectors_home = config.get(CONF_AREAS_ARM_HOME) or []
+        self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT) or []
+        self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION) or []
 
         # Alarm state
         self.state = STATE_UNAVAILABLE
-        self._inventory = {}
 
     @property
     def inputs(self):

--- a/custom_components/econnect_metronet/exceptions.py
+++ b/custom_components/econnect_metronet/exceptions.py
@@ -1,5 +1,0 @@
-from homeassistant.exceptions import HomeAssistantError
-
-
-class InvalidAreas(HomeAssistantError):
-    """Error to indicate given areas are invalid."""

--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -9,42 +9,38 @@ from .exceptions import InvalidAreas
 
 
 def parse_areas_config(config: str, raises: bool = False):
-    """Parses a comma-separated string of area configurations into a list of integers.
+    """Extracts sector numbers from the provided configuration.
 
-    Takes a string containing comma-separated area IDs and converts it to a list of integers.
-    In case of any parsing errors, either raises a custom `InvalidAreas` exception or returns an empty list
-    based on the `raises` flag.
-
-    Args:
-        config (str): A comma-separated string of area IDs, e.g., "3,4".
-        raises (bool, optional): Determines the error handling behavior. If `True`, the function
-                                 raises the `InvalidAreas` exception upon encountering a parsing error.
-                                 If `False`, it suppresses the error and returns an empty list.
-                                 Defaults to `False`.
+    Parameters:
+        config (str or None): A string containing sector configurations in the format "number:name".
+            If empty or None, an empty list is returned.
+        raises (bool, optional): If True, raises an InvalidAreas exception if there's an error in parsing.
+            Defaults to True.
 
     Returns:
-        list[int]: A list of integers representing area IDs. If parsing fails and `raises` is `False`,
-                   returns an empty list.
+        list: A list of integers representing the extracted sector numbers.
 
     Raises:
-        InvalidAreas: If there's a parsing error and the `raises` flag is set to `True`.
+        InvalidAreas: If raises is set to True and there is an error in parsing.
 
-    Examples:
-        >>> parse_areas_config("3,4")
-        [3, 4]
-        >>> parse_areas_config("3,a")
-        []
+    Example:
+        >>> config = "1:sector1 2:sector2 3:sector3"
+        >>> parse_areas_config(config)
+        [1, 2, 3]
     """
     if config == "" or config is None:
         # Empty config is considered valid (no sectors configured)
         return []
-
-    try:
-        return [int(x) for x in config.split(",")]
-    except (ValueError, AttributeError):
-        if raises:
-            raise InvalidAreas
-        return []
+    result = []
+    for item in config:
+        try:
+            number = int(item.split(":")[0])
+            result.append(number)
+        except (ValueError, AttributeError):
+            if raises:
+                raise InvalidAreas
+            return []
+    return result
 
 
 def generate_entity_id(config: ConfigEntry, name: Union[str, None] = None) -> str:

--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -24,7 +24,7 @@ def parse_areas_config(config: str, raises: bool = False):
         InvalidAreas: If raises is set to True and there is an error in parsing.
 
     Example:
-        >>> config = "1:sector1 2:sector2 3:sector3"
+        >>> config = (1 : sector1, 2 : sector2, 3 : sector3)
         >>> parse_areas_config(config)
         [1, 2, 3]
     """

--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -7,7 +7,6 @@ from homeassistant.helpers.config_validation import multi_select
 from homeassistant.util import slugify
 
 from .const import CONF_SYSTEM_NAME, DOMAIN
-from .exceptions import InvalidAreas
 
 
 class select(multi_select):
@@ -51,41 +50,6 @@ class select(multi_select):
                 raise vol.Invalid(f"{value} is not a valid option")
 
         return selected
-
-
-def parse_areas_config(config: str, raises: bool = False):
-    """Extracts sector numbers from the provided configuration.
-
-    Parameters:
-        config (str or None): A string containing sector configurations in the format "number:name".
-            If empty or None, an empty list is returned.
-        raises (bool, optional): If True, raises an InvalidAreas exception if there's an error in parsing.
-            Defaults to True.
-
-    Returns:
-        list: A list of integers representing the extracted sector numbers.
-
-    Raises:
-        InvalidAreas: If raises is set to True and there is an error in parsing.
-
-    Example:
-        >>> config = (1 : sector1, 2 : sector2, 3 : sector3)
-        >>> parse_areas_config(config)
-        [1, 2, 3]
-    """
-    if config == "" or config is None:
-        # Empty config is considered valid (no sectors configured)
-        return []
-    result = []
-    for item in config:
-        try:
-            number = int(item.split(":")[0])
-            result.append(number)
-        except (ValueError, AttributeError):
-            if raises:
-                raise InvalidAreas
-            return []
-    return result
 
 
 def generate_entity_id(config: ConfigEntry, name: Union[str, None] = None) -> str:

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -18,7 +18,7 @@
                     "system_name": "Name of the control panel (optional)"
                 },
                 "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
-                "title": "Configure your eConnect/Metronet system"
+                "title": "Configure your e-Connect/Metronet system"
             }
         }
     },
@@ -36,7 +36,7 @@
                     "scan_interval": "Scan interval (e.g. 120 - optional)"
                 },
                 "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
-                "title": "Configure your eConnect/Metronet system"
+                "title": "Configure your e-Connect/Metronet system"
             }
         }
     },

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -18,7 +18,7 @@
                     "system_name": "Name of the control panel (optional)"
                 },
                 "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
-                "title": "Configure your Elmo/IESS system"
+                "title": "Configure your eConnect/Metronet system"
             }
         }
     },
@@ -30,13 +30,13 @@
         "step": {
             "init": {
                 "data": {
-                    "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
-                    "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-                    "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+                    "areas_arm_home": "Armed areas while at home (optional)",
+                    "areas_arm_night": "Armed areas at night (optional)",
+                    "areas_arm_vacation": "Armed areas when you are on vacation (optional)",
                     "scan_interval": "Scan interval (e.g. 120 - optional)"
                 },
                 "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
-                "title": "Configure your Elmo/IESS system"
+                "title": "Configure your eConnect/Metronet system"
             }
         }
     },

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -18,7 +18,7 @@
                     "system_name": "Nome dell'impianto (opzionale)"
                 },
                 "description": "Fornisci le tue credenziali e il dominio utilizzato per accedere alla tua pagina di login via web.\n\nAd esempio, se accedi a `https://connect.elmospa.com/installatore/`, devi impostare il dominio su `installatore`. Nel caso in cui non hai un installatore definito, impostalo su `default`.\n\nPuoi configurare il sistema selezionando \"Opzioni\" dopo aver installato l'integrazione.",
-                "title": "Configura il tuo sistema Elmo/IESS"
+                "title": "Configura il tuo sistema eConnect/Metronet"
             }
         }
     },
@@ -30,13 +30,13 @@
         "step": {
             "init": {
                 "data": {
-                    "areas_arm_home": "Settori armati mentre sei a casa (es. 3,4 - opzionale)",
-                    "areas_arm_night": "Settori armati di notte (es. 3,4 - opzionale)",
-                    "areas_arm_vacation": "Settori armati quando sei in vacanza (es. 3,4 - opzionale)",
+                    "areas_arm_home": "Settori armati mentre sei a casa (opzionale)",
+                    "areas_arm_night": "Settori armati di notte (opzionale)",
+                    "areas_arm_vacation": "Settori armati quando sei in vacanza (opzionale)",
                     "scan_interval": "Intervallo di scansione (es. 120 - opzionale)"
                 },
-                "description": "Definisci i settori che desideri armare in diverse modalità.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
-                "title": "Configura il tuo sistema Elmo/IESS"
+                "description": "Scegli, tra quelli proposti, i settori che desideri armare nelle diverse modalità.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
+                "title": "Configura il tuo sistema eConnect/Metronet"
             }
         }
     },

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -18,7 +18,7 @@
                     "system_name": "Nome dell'impianto (opzionale)"
                 },
                 "description": "Fornisci le tue credenziali e il dominio utilizzato per accedere alla tua pagina di login via web.\n\nAd esempio, se accedi a `https://connect.elmospa.com/installatore/`, devi impostare il dominio su `installatore`. Nel caso in cui non hai un installatore definito, impostalo su `default`.\n\nPuoi configurare il sistema selezionando \"Opzioni\" dopo aver installato l'integrazione.",
-                "title": "Configura il tuo sistema eConnect/Metronet"
+                "title": "Configura il tuo sistema e-Connect/Metronet"
             }
         }
     },
@@ -36,7 +36,7 @@
                     "scan_interval": "Intervallo di scansione (es. 120 - opzionale)"
                 },
                 "description": "Scegli, tra quelli proposti, i settori che desideri armare nelle diverse modalità.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
-                "title": "Configura il tuo sistema eConnect/Metronet"
+                "title": "Configura il tuo sistema e-Connect/Metronet"
             }
         }
     },

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -36,9 +36,9 @@ def test_device_constructor(client):
 def test_device_constructor_with_config(client):
     """Should initialize defaults attributes to run properly."""
     config = {
-        CONF_AREAS_ARM_HOME: "3, 4",
-        CONF_AREAS_ARM_NIGHT: "1, 2, 3",
-        CONF_AREAS_ARM_VACATION: "5, 3",
+        CONF_AREAS_ARM_HOME: ("3 : Casa\nRadar", "4 : Garage\nRadar"),
+        CONF_AREAS_ARM_NIGHT: ("1 : Casa\nFinestre", "2 : Casa\nPersiane", "3 : Casa\nRadar"),
+        CONF_AREAS_ARM_VACATION: ("5 : Garage\nCler", "3 : Casa\nRadar"),
     }
     device = AlarmDevice(client, config=config)
     # Test

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -36,9 +36,9 @@ def test_device_constructor(client):
 def test_device_constructor_with_config(client):
     """Should initialize defaults attributes to run properly."""
     config = {
-        CONF_AREAS_ARM_HOME: ("3 : Casa\nRadar", "4 : Garage\nRadar"),
-        CONF_AREAS_ARM_NIGHT: ("1 : Casa\nFinestre", "2 : Casa\nPersiane", "3 : Casa\nRadar"),
-        CONF_AREAS_ARM_VACATION: ("5 : Garage\nCler", "3 : Casa\nRadar"),
+        CONF_AREAS_ARM_HOME: [3, 4],
+        CONF_AREAS_ARM_NIGHT: [1, 2, 3],
+        CONF_AREAS_ARM_VACATION: [5, 3],
     }
     device = AlarmDevice(client, config=config)
     # Test

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -51,6 +51,24 @@ def test_device_constructor_with_config(client):
     assert device.state == STATE_UNAVAILABLE
 
 
+def test_device_constructor_with_config_empty(client):
+    """Should initialize defaults attributes to run properly."""
+    config = {
+        CONF_AREAS_ARM_HOME: None,
+        CONF_AREAS_ARM_NIGHT: None,
+        CONF_AREAS_ARM_VACATION: None,
+    }
+    device = AlarmDevice(client, config=config)
+    # Test
+    assert device._connection == client
+    assert device._inventory == {}
+    assert device._last_ids == {10: 0, 9: 0, 11: 0}
+    assert device._sectors_home == []
+    assert device._sectors_night == []
+    assert device._sectors_vacation == []
+    assert device.state == STATE_UNAVAILABLE
+
+
 class TestItemInputs:
     def test_without_status(self, alarm_device):
         """Verify that querying items without specifying a status works correctly"""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,10 +9,13 @@ from custom_components.econnect_metronet.helpers import (
 
 
 def test_parse_areas_config_valid_input():
-    input = ("4 : Garage\nCler", "5 : Garage\nRadar")
-    input2 = ("2 : Casa\nFinestre", "3 : Casa\nRadar", "4 : Garage\nCler", "5 : Garage\nRadar")
-    assert parse_areas_config(input) == [4, 5]
-    assert parse_areas_config(input2) == [2, 3, 4, 5]
+    assert parse_areas_config(("4 : Garage\nCler", "5 : Garage\nRadar")) == [4, 5]
+    assert parse_areas_config(("2 : Casa\nFinestre", "3 : Casa\nRadar", "4 : Garage\nCler", "5 : Garage\nRadar")) == [
+        2,
+        3,
+        4,
+        5,
+    ]
     assert parse_areas_config("") == []
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,9 +9,10 @@ from custom_components.econnect_metronet.helpers import (
 
 
 def test_parse_areas_config_valid_input():
-    assert parse_areas_config("3,4") == [3, 4]
-    assert parse_areas_config("1,2,3,4,5") == [1, 2, 3, 4, 5]
-    assert parse_areas_config("10") == [10]
+    input = ("4 : Garage\nCler", "5 : Garage\nRadar")
+    input2 = ("2 : Casa\nFinestre", "3 : Casa\nRadar", "4 : Garage\nCler", "5 : Garage\nRadar")
+    assert parse_areas_config(input) == [4, 5]
+    assert parse_areas_config(input2) == [2, 3, 4, 5]
     assert parse_areas_config("") == []
 
 
@@ -31,10 +32,6 @@ def test_parse_areas_config_raises_value_error():
         parse_areas_config("3,a", raises=True)
     with pytest.raises(InvalidAreas):
         parse_areas_config("3.4", raises=True)
-
-
-def test_parse_areas_config_whitespace():
-    assert parse_areas_config(" 3 , 4 ") == [3, 4]
 
 
 def test_generate_entity_name_empty(config_entry):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,40 +1,6 @@
-import pytest
 from homeassistant.core import valid_entity_id
 
-from custom_components.econnect_metronet.exceptions import InvalidAreas
-from custom_components.econnect_metronet.helpers import (
-    generate_entity_id,
-    parse_areas_config,
-)
-
-
-def test_parse_areas_config_valid_input():
-    assert parse_areas_config(("4 : Garage\nCler", "5 : Garage\nRadar")) == [4, 5]
-    assert parse_areas_config(("2 : Casa\nFinestre", "3 : Casa\nRadar", "4 : Garage\nCler", "5 : Garage\nRadar")) == [
-        2,
-        3,
-        4,
-        5,
-    ]
-    assert parse_areas_config("") == []
-
-
-def test_parse_areas_config_valid_empty_input():
-    assert parse_areas_config("", raises=True) == []
-    assert parse_areas_config(None, raises=True) == []
-
-
-def test_parse_areas_config_invalid_input():
-    assert parse_areas_config("3,a") == []
-    assert parse_areas_config("3.4") == []
-    assert parse_areas_config("3,") == []
-
-
-def test_parse_areas_config_raises_value_error():
-    with pytest.raises(InvalidAreas):
-        parse_areas_config("3,a", raises=True)
-    with pytest.raises(InvalidAreas):
-        parse_areas_config("3.4", raises=True)
+from custom_components.econnect_metronet.helpers import generate_entity_id
 
 
 def test_generate_entity_name_empty(config_entry):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,67 @@
+from custom_components.econnect_metronet import async_migrate_entry
+from custom_components.econnect_metronet.const import DOMAIN
+
+from .helpers import MockConfigEntry
+
+
+async def test_async_no_migrations(mocker, hass, config_entry):
+    spy = mocker.spy(hass.config_entries, "async_update_entry")
+    # Test
+    result = await async_migrate_entry(hass, config_entry)
+    assert result is True
+    assert spy.call_count == 0
+
+
+async def test_async_migrate_from_v1(hass):
+    config_entry = MockConfigEntry(
+        version=1,
+        domain=DOMAIN,
+        entry_id="test_entry_id",
+        options={},
+        data={
+            "username": "test_user",
+            "password": "test_password",
+            "domain": "econnect_metronet",
+        },
+    )
+    # Test
+    result = await async_migrate_entry(hass, config_entry)
+    assert result is True
+    assert config_entry.version == 3
+    assert config_entry.options == {}
+    assert config_entry.data == {
+        "username": "test_user",
+        "password": "test_password",
+        "domain": "econnect_metronet",
+        "system_base_url": "https://connect.elmospa.com",
+    }
+
+
+async def test_async_migrate_from_v2(hass):
+    config_entry = MockConfigEntry(
+        version=2,
+        domain=DOMAIN,
+        entry_id="test_entry_id",
+        options={
+            "areas_arm_home": "1,2",
+            "areas_arm_night": "1,2",
+            "areas_arm_vacation": "1,2",
+            "scan_interval": 60,
+        },
+        data={
+            "username": "test_user",
+            "password": "test_password",
+            "domain": "econnect_metronet",
+            "system_base_url": "https://example.com",
+        },
+    )
+    # Test
+    result = await async_migrate_entry(hass, config_entry)
+    assert result is True
+    assert config_entry.version == 3
+    assert config_entry.options == {
+        "areas_arm_home": [1, 2],
+        "areas_arm_night": [1, 2],
+        "areas_arm_vacation": [1, 2],
+        "scan_interval": 60,
+    }

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -5,9 +5,7 @@ from voluptuous.error import MultipleInvalid
 from custom_components.econnect_metronet.const import DOMAIN, KEY_DEVICE
 
 
-class TestOptionsFlowHandler:
-    """Available options: [(1, 'S1 Living Room'), (2, 'S2 Bedroom'), (3, 'S3 Outdoor')]"""
-
+class TestOptionsFlow:
     @pytest.fixture(autouse=True)
     def setup(self, hass, config_entry, alarm_device):
         self.hass = hass
@@ -19,7 +17,7 @@ class TestOptionsFlowHandler:
         }
 
     async def test_form_fields(self, hass, config_entry):
-        # Test
+        # Ensure form is loaded with the correct fields
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -39,7 +37,6 @@ class TestOptionsFlowHandler:
 
     async def test_form_submit_successful_empty(self, hass, config_entry):
         # Ensure an empty form can be submitted successfully
-        config_entry.add_to_hass(hass)
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -55,8 +52,7 @@ class TestOptionsFlowHandler:
         assert result["data"] == {"areas_arm_vacation": [], "areas_arm_home": [], "areas_arm_night": []}
 
     async def test_form_submit_invalid_type(self, hass, config_entry):
-        # Ensure it fails if an option not in the list is submitted
-        config_entry.add_to_hass(hass)
+        # Ensure it fails if a user submits an option with an invalid type
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -72,8 +68,7 @@ class TestOptionsFlowHandler:
         assert excinfo.value.errors[0].msg == "Not a list"
 
     async def test_form_submit_invalid_input(self, hass, config_entry):
-        # Ensure it fails if an option not in the list is submitted
-        config_entry.add_to_hass(hass)
+        # Ensure it fails if a user submits an option not in the allowed list
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -91,8 +86,7 @@ class TestOptionsFlowHandler:
         assert excinfo.value.errors[0].msg == "(3, 'Garden') is not a valid option"
 
     async def test_form_submit_successful_with_identifier(self, hass, config_entry):
-        # Ensure a single field can be submitted successfully
-        config_entry.add_to_hass(hass)
+        # Ensure users can submit an option just by using the option ID
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -115,8 +109,7 @@ class TestOptionsFlowHandler:
         assert result["result"] is True
 
     async def test_form_submit_successful_with_input(self, hass, config_entry):
-        # Ensure a single field can be submitted successfully
-        config_entry.add_to_hass(hass)
+        # Ensure users can submit an option that is available in the allowed list
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )
@@ -141,8 +134,7 @@ class TestOptionsFlowHandler:
         assert result["result"] is True
 
     async def test_form_submit_successful_with_multiple_inputs(self, hass, config_entry):
-        # Ensure a single field can be submitted successfully
-        config_entry.add_to_hass(hass)
+        # Ensure multiple options can be submitted at once
         form = await hass.config_entries.options.async_init(
             config_entry.entry_id, context={"show_advanced_options": False}
         )


### PR DESCRIPTION
### Related Issues

Closes #60 

### Proposed Changes:
Transform the configuration of sectors in the options flow from textual input to a multi-select interface for a better and more user-friendly experience:
- Add `select` component for the `OptionsFlow`
- Include migration between options v2 -> v3 to avoid breaking changes
- Remove `parse_areas_config` utility as validation is handled in the `select` component

### Testing:


### Extra Notes (optional):
Old method:

![Screenshot 2023-11-01 143109](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/23960bf8-1531-4579-9ebd-99fe5939778d)

New method:


![Screenshot 2023-10-28 151540](https://github.com/palazzem/ha-econnect-alarm/assets/76836856/dcb76884-d662-48ea-a1e6-920c1ffe7101)


### Checklist

- [X] Related issues and proposed changes are filled
- [X] Tests are defining the correct and expected behavior
- [X] Code is well-documented via docstrings
