### PR TITLE
tests(config_flow): add coverage for config exceptions; refactor `ConfigFlow` tests

### DIFF
--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -1,12 +1,10 @@
 from typing import Union
 
-from elmo.api.client import ElmoClient
-from homeassistant import core
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_USERNAME
 from homeassistant.util import slugify
 
-from .const import CONF_DOMAIN, CONF_SYSTEM_NAME, CONF_SYSTEM_URL, DOMAIN
+from .const import CONF_SYSTEM_NAME, DOMAIN
 from .exceptions import InvalidAreas
 
 
@@ -47,29 +45,6 @@ def parse_areas_config(config: str, raises: bool = False):
         if raises:
             raise InvalidAreas
         return []
-
-
-async def validate_credentials(hass: core.HomeAssistant, config: dict):
-    """Validate if user input includes valid credentials to connect.
-
-    Initialize the client with an API endpoint and a vendor and authenticate
-    your connection to retrieve the access token.
-
-    Args:
-        hass: HomeAssistant instance.
-        data: data that needs validation (configured username/password).
-    Raises:
-        ConnectionError: if there is a connection error.
-        CredentialError: if given credentials are incorrect.
-        HTTPError: if the API backend answers with errors.
-    Returns:
-        `True` if given `data` includes valid credential checked with
-        e-connect backend.
-    """
-    # Check Credentials
-    client = ElmoClient(config.get(CONF_SYSTEM_URL), domain=config.get(CONF_DOMAIN))
-    await hass.async_add_executor_job(client.auth, config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
-    return True
 
 
 def generate_entity_id(config: ConfigEntry, name: Union[str, None] = None) -> str:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,14 @@
+def _(mock_path: str) -> str:
+    """Helper to simplify Mock path strings.
+
+    Args:
+        mock_path (str): The partial path to be appended to the standard prefix for mock paths.
+
+    Returns:
+        str: The full mock path combined with the standard prefix.
+
+    Example:
+        >>> _("module.Class.method")
+        "custom_components.econnect_metronet.module.Class.method"
+    """
+    return f"custom_components.econnect_metronet.{mock_path}"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

This change improves the testing in the following areas:
1. Removes `validate_credentials` as it was a level of indirection. This makes testing straightforward as we don't need to test any helper.
2. Adds `_()` test helper that makes mocking easier with long python paths.
3. Refactors `ConfigFlow` tests so that they use `pytest-mock` properly.
4. Fixes `pytest-mock` by removing context managers as they are not needed.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
