### PR TITLE
tests: replace custom MockConfigEntry with the official `hass.MockConfigEntry`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,5 @@ repos:
   rev: v1.5.1
   hooks:
     - id: mypy
-      exclude: tests/hass/
+      exclude: tests/|tests/hass/
       additional_dependencies: [types-requests]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet import async_setup
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
+from custom_components.econnect_metronet.config_flow import EconnectConfigFlow
 from custom_components.econnect_metronet.const import DOMAIN
 from custom_components.econnect_metronet.coordinator import AlarmCoordinator
 from custom_components.econnect_metronet.devices import AlarmDevice
 
 from .fixtures import responses as r
+from .helpers import MockConfigEntry
 
 pytest_plugins = ["tests.hass.fixtures"]
 
@@ -141,19 +143,15 @@ def config_entry():
     This config entry is designed to emulate the behavior of a real config entry for
     testing purposes.
     """
-
-    class MockConfigEntry:
-        def __init__(self):
-            # Config at install-time
-            self.data = {
-                "username": "test_user",
-                "password": "test_password",
-                "system_base_url": "https://example.com",
-                "domain": "econnect_metronet",
-            }
-
-            # Options at configuration-time
-            self.entry_id = "test_entry_id"
-            self.options = {}
-
-    return MockConfigEntry()
+    return MockConfigEntry(
+        version=EconnectConfigFlow.VERSION,
+        domain=DOMAIN,
+        entry_id="test_entry_id",
+        options={},
+        data={
+            "username": "test_user",
+            "password": "test_password",
+            "domain": "econnect_metronet",
+            "system_base_url": "https://example.com",
+        },
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,14 @@
+from .hass.common import MockConfigEntry as BaseMockConfigEntry
+
+
+class MockConfigEntry(BaseMockConfigEntry):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Make settings overridable
+        self.data = kwargs.get("data", {})
+        self.options = kwargs.get("options", {})
+
+
 def _(mock_path: str) -> str:
     """Helper to simplify Mock path strings.
 


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

Instead of using our own `MockConfigEntry`, we're using the one provided directly from HA. It behaves exactly as the original one, with the only difference that we remove the `MappingProxyType` mapping (read-only protection) as we want to override values during tests.

This change is required to use `config_entry` fixture while testing our `OptionsFlow`.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
