### PR TITLE
feat: add AWAY state configuration

### DIFF
--- a/custom_components/econnect_metronet/alarm_control_panel.py
+++ b/custom_components/econnect_metronet/alarm_control_panel.py
@@ -100,7 +100,7 @@ class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
     @set_device_state(STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMING)
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        await self.hass.async_add_executor_job(self._device.arm, code)
+        await self.hass.async_add_executor_job(self._device.arm, code, self._device._sectors_away)
 
     @set_device_state(STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMING)
     async def async_alarm_arm_home(self, code=None):

--- a/custom_components/econnect_metronet/config_flow.py
+++ b/custom_components/econnect_metronet/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.core import callback
 from requests.exceptions import ConnectionError, HTTPError
 
 from .const import (
+    CONF_AREAS_ARM_AWAY,
     CONF_AREAS_ARM_HOME,
     CONF_AREAS_ARM_NIGHT,
     CONF_AREAS_ARM_VACATION,
@@ -104,7 +105,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     """Reconfigure integration options.
 
     Available options are:
-        * Areas armed in Arm Away state
+        * Areas armed in Arm Away state. If not set all sectors are armed.
+        * Areas armed in Arm Home state
         * Areas armed in Arm Night state
         * Areas armed in Arm Vacation state
     """
@@ -131,6 +133,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
+                    vol.Optional(
+                        CONF_AREAS_ARM_AWAY,
+                        default=self.config_entry.options.get(CONF_AREAS_ARM_AWAY, []),
+                    ): select(sectors),
                     vol.Optional(
                         CONF_AREAS_ARM_HOME,
                         default=self.config_entry.options.get(CONF_AREAS_ARM_HOME, []),

--- a/custom_components/econnect_metronet/const.py
+++ b/custom_components/econnect_metronet/const.py
@@ -8,6 +8,7 @@ SUPPORTED_SYSTEMS = {
 CONF_DOMAIN = "domain"
 CONF_SYSTEM_URL = "system_base_url"
 CONF_SYSTEM_NAME = "system_name"
+CONF_AREAS_ARM_AWAY = "areas_arm_away"
 CONF_AREAS_ARM_HOME = "areas_arm_home"
 CONF_AREAS_ARM_NIGHT = "areas_arm_night"
 CONF_AREAS_ARM_VACATION = "areas_arm_vacation"

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -13,7 +13,12 @@ from homeassistant.const import (
 )
 from requests.exceptions import HTTPError
 
-from .const import CONF_AREAS_ARM_HOME, CONF_AREAS_ARM_NIGHT, CONF_AREAS_ARM_VACATION
+from .const import (
+    CONF_AREAS_ARM_AWAY,
+    CONF_AREAS_ARM_HOME,
+    CONF_AREAS_ARM_NIGHT,
+    CONF_AREAS_ARM_VACATION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +50,7 @@ class AlarmDevice:
 
         # Load user configuration
         config = config or {}
+        self._sectors_away = config.get(CONF_AREAS_ARM_AWAY) or []
         self._sectors_home = config.get(CONF_AREAS_ARM_HOME) or []
         self._sectors_night = config.get(CONF_AREAS_ARM_NIGHT) or []
         self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION) or []

--- a/custom_components/econnect_metronet/strings.json
+++ b/custom_components/econnect_metronet/strings.json
@@ -30,13 +30,14 @@
         "step": {
             "init": {
                 "data": {
-                    "areas_arm_home": "Armed areas while at home (e.g 3,4 - optional)",
-                    "areas_arm_night": "Armed areas at night (e.g. 3,4 - optional)",
-                    "areas_arm_vacation": "Armed areas when you are on vacation (e.g. 3,4 - optional)",
+                    "areas_arm_away": "Armed areas while away (unset to arm all areas)",
+                    "areas_arm_home": "Armed areas while at home (optional)",
+                    "areas_arm_night": "Armed areas at night (optional)",
+                    "areas_arm_vacation": "Armed areas when you are on vacation (optional)",
                     "scan_interval": "Scan interval (e.g. 120 - optional)"
                 },
-                "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
-                "title": "Configure your Elmo/IESS system"
+                "description": "Define sectors you want to arm in different modes. If AWAY section is unset, all sectors are armed.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
+                "title": "Configure your e-Connect/Metronet system"
             }
         }
     },

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -30,12 +30,13 @@
         "step": {
             "init": {
                 "data": {
+                    "areas_arm_away": "Armed areas while away (unset to arm all areas)",
                     "areas_arm_home": "Armed areas while at home (optional)",
                     "areas_arm_night": "Armed areas at night (optional)",
                     "areas_arm_vacation": "Armed areas when you are on vacation (optional)",
                     "scan_interval": "Scan interval (e.g. 120 - optional)"
                 },
-                "description": "Define sectors you want to arm in different modes.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
+                "description": "Define sectors you want to arm in different modes. If AWAY section is unset, all sectors are armed.\n\nSet 'Scan Interval' value only if you want to reduce data usage, in case the system is connected through a mobile network. Leave it empty for real time updates, or set it to a value in seconds (e.g. 120 for one update every 2 minutes)",
                 "title": "Configure your e-Connect/Metronet system"
             }
         }

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -30,12 +30,13 @@
         "step": {
             "init": {
                 "data": {
+                    "areas_arm_away": "Settori armati mentre sei fuori casa (attiva tutti i settori se non configurato)",
                     "areas_arm_home": "Settori armati mentre sei a casa (opzionale)",
                     "areas_arm_night": "Settori armati di notte (opzionale)",
                     "areas_arm_vacation": "Settori armati quando sei in vacanza (opzionale)",
                     "scan_interval": "Intervallo di scansione (es. 120 - opzionale)"
                 },
-                "description": "Scegli, tra quelli proposti, i settori che desideri armare nelle diverse modalità.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
+                "description": "Scegli, tra quelli proposti, i settori che desideri armare nelle diverse modalità. Se l'opzione FUORI CASA non venisse configurata, tutti i settori saranno attivati in allarme.\n\nImposta il valore 'Intervallo di scansione' solo se desideri ridurre l'utilizzo dei dati, nel caso in cui il sistema sia connesso tramite una rete mobile (SIM). Lascialo vuoto per aggiornamenti in tempo reale, oppure imposta un valore in secondi (es. 120 per un aggiornamento ogni 2 minuti)",
                 "title": "Configura il tuo sistema e-Connect/Metronet"
             }
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
-import logging
-
 import pytest
 import responses
 from elmo.api.client import ElmoClient
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet import async_setup
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
@@ -53,7 +50,7 @@ def alarm_device(client):
 
 
 @pytest.fixture(scope="function")
-def alarm_entity(hass, client, config_entry):
+def panel(hass, config_entry, alarm_device, coordinator):
     """Fixture to provide a test instance of the EconnectAlarm entity.
 
     This sets up an AlarmDevice and its corresponding DataUpdateCoordinator,
@@ -67,11 +64,9 @@ def alarm_entity(hass, client, config_entry):
     Yields:
         EconnectAlarm: Initialized test instance of the EconnectAlarm entity.
     """
-    device = AlarmDevice(client)
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
-    entity = EconnectAlarm(unique_id="test_id", config=config_entry, device=device, coordinator=coordinator)
+    entity = EconnectAlarm(unique_id="test_id", config=config_entry, device=alarm_device, coordinator=coordinator)
     entity.hass = hass
-    yield entity
+    return entity
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
@@ -38,3 +39,24 @@ def test_alarm_panel_entity_id_with_system_name(client, hass, config_entry):
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
     assert entity.entity_id == "econnect_metronet.econnect_metronet_home"
+
+
+@pytest.mark.asyncio
+async def test_alarm_panel_arm_away(mocker, panel):
+    # Ensure an empty AWAY config arms all sectors
+    arm = mocker.patch.object(panel._device._connection, "arm", autopsec=True)
+    # Test
+    await panel.async_alarm_arm_away(code=42)
+    assert arm.call_count == 1
+    assert arm.call_args.kwargs["sectors"] == []
+
+
+@pytest.mark.asyncio
+async def test_alarm_panel_arm_away_with_options(mocker, panel):
+    # Ensure an empty AWAY config arms all sectors
+    arm = mocker.patch.object(panel._device._connection, "arm", autopsec=True)
+    panel._device._sectors_away = [1, 2]
+    # Test
+    await panel.async_alarm_arm_away(code=42)
+    assert arm.call_count == 1
+    assert arm.call_args.kwargs["sectors"] == [1, 2]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,7 +5,7 @@ from custom_components.econnect_metronet.decorators import set_device_state
 
 
 @pytest.mark.asyncio
-async def test_set_device_state_successful(alarm_entity):
+async def test_set_device_state_successful(panel):
     """Should update the device state to the new state."""
 
     @set_device_state("new_state", "loader_state")
@@ -13,38 +13,40 @@ async def test_set_device_state_successful(alarm_entity):
         pass
 
     # Test
-    await test_func(alarm_entity)
-    assert alarm_entity._device.state == "new_state"
+    await test_func(panel)
+    assert panel._device.state == "new_state"
 
 
 @pytest.mark.asyncio
-async def test_set_device_state_lock_error(alarm_entity):
+async def test_set_device_state_lock_error(panel):
     """Should revert the device state to the previous state."""
 
     @set_device_state("new_state", "loader_state")
     async def test_func(self):
         raise LockError()
 
+    panel._device.state = "old_state"
     # Test
-    await test_func(alarm_entity)
-    assert alarm_entity._device.state == "unavailable"
+    await test_func(panel)
+    assert panel._device.state == "old_state"
 
 
 @pytest.mark.asyncio
-async def test_set_device_state_code_error(alarm_entity):
+async def test_set_device_state_code_error(panel):
     """Should revert the device state to the previous state."""
 
     @set_device_state("new_state", "loader_state")
     async def test_func(self):
         raise CodeError()
 
+    panel._device.state = "old_state"
     # Test
-    await test_func(alarm_entity)
-    assert alarm_entity._device.state == "unavailable"
+    await test_func(panel)
+    assert panel._device.state == "old_state"
 
 
 @pytest.mark.asyncio
-async def test_set_device_state_loader_state(alarm_entity):
+async def test_set_device_state_loader_state(panel):
     """Should use the loader_state until the function is completed."""
 
     @set_device_state("new_state", "loader_state")
@@ -53,4 +55,4 @@ async def test_set_device_state_loader_state(alarm_entity):
         assert self._device.state == "loader_state"
 
     # Run test
-    await test_func(alarm_entity)
+    await test_func(panel)

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -25,11 +25,13 @@ class TestOptionsFlow:
         assert form["step_id"] == "init"
         assert form["errors"] == {}
         assert list(form["data_schema"].schema.keys()) == [
+            "areas_arm_away",
             "areas_arm_home",
             "areas_arm_night",
             "areas_arm_vacation",
             "scan_interval",
         ]
+        assert isinstance(form["data_schema"].schema["areas_arm_away"], select)
         assert isinstance(form["data_schema"].schema["areas_arm_home"], select)
         assert isinstance(form["data_schema"].schema["areas_arm_night"], select)
         assert isinstance(form["data_schema"].schema["areas_arm_vacation"], select)
@@ -49,7 +51,12 @@ class TestOptionsFlow:
         # Check HA config
         assert result["type"] == "create_entry"
         assert result["title"] == "e-Connect/Metronet Alarm"
-        assert result["data"] == {"areas_arm_vacation": [], "areas_arm_home": [], "areas_arm_night": []}
+        assert result["data"] == {
+            "areas_arm_vacation": [],
+            "areas_arm_home": [],
+            "areas_arm_night": [],
+            "areas_arm_away": [],
+        }
 
     async def test_form_submit_invalid_type(self, hass, config_entry):
         # Ensure it fails if a user submits an option with an invalid type
@@ -102,6 +109,7 @@ class TestOptionsFlow:
         assert result["type"] == "create_entry"
         assert result["title"] == "e-Connect/Metronet Alarm"
         assert result["data"] == {
+            "areas_arm_away": [],
             "areas_arm_home": [1],
             "areas_arm_night": [],
             "areas_arm_vacation": [],
@@ -127,6 +135,7 @@ class TestOptionsFlow:
         assert result["type"] == "create_entry"
         assert result["title"] == "e-Connect/Metronet Alarm"
         assert result["data"] == {
+            "areas_arm_away": [],
             "areas_arm_home": [(1, "S1 Living Room")],
             "areas_arm_night": [],
             "areas_arm_vacation": [],
@@ -142,6 +151,9 @@ class TestOptionsFlow:
         result = await hass.config_entries.options.async_configure(
             form["flow_id"],
             user_input={
+                "areas_arm_away": [
+                    (2, "S2 Bedroom"),
+                ],
                 "areas_arm_home": [
                     (1, "S1 Living Room"),
                 ],
@@ -156,6 +168,7 @@ class TestOptionsFlow:
         assert result["type"] == "create_entry"
         assert result["title"] == "e-Connect/Metronet Alarm"
         assert result["data"] == {
+            "areas_arm_away": [(2, "S2 Bedroom")],
             "areas_arm_home": [(1, "S1 Living Room")],
             "areas_arm_night": [(1, "S1 Living Room")],
             "areas_arm_vacation": [(1, "S1 Living Room"), (2, "S2 Bedroom")],


### PR DESCRIPTION
### Related Issues

- Closes #96 

### Proposed Changes:

Adds arm AWAY configuration in the `OptionsFlow` step with the following logic:
- After version update, the setting is empty
- If the setting is not set (empty), the device arms all sectors (backward compatibility)
- If the setting is set, only selected sectors are armed

#### Example
<img width="500" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/21593560-434f-499d-9c7d-706741ee6536">


### Testing:

1. Arming the system without setting the option should arm all sectors
2. Arming the system with the option set, should arm only selected sectors

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
