### PR TITLE
feat: provide HA instance via `compose.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Home Assistant configuration
+config/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ pip install -e '.[all]'
 pre-commit install
 ```
 
+### Testing Changes in Home Assistant
+
+To test your changes in an actual Home Assistant environment, you may use the Docker container available in our
+`compose.yaml` file. Launch the container with the following command:
+
+```bash
+docker compose up -d
+```
+
+Then, navigate to `http://localhost:8123` in your web browser to set up your Home Assistant instance. Follow the standard
+procedure to install the integration, as you would in a typical installation.
+
+The container is configured to automatically mount the `custom_components/` and `config/` directories from your local
+workspace. To see changes reflected in Home Assistant, make sure to restart the instance through the UI each time
+you update the integration.
+
 ### Coding Guidelines
 
 To maintain a consistent codebase, we utilize [flake8][1] and [black][2]. Consistency is crucial as it

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  homeassistant:
+    container_name: hass-dev
+    image: "ghcr.io/home-assistant/home-assistant:stable"
+    volumes:
+      - ${PWD}/config:/config
+      - ${PWD}/custom_components:/config/custom_components
+      - /etc/localtime:/etc/localtime:ro
+      - /run/dbus:/run/dbus:ro
+    ports:
+      - "127.0.0.1:8123:8123"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

Provides a Docker container defined in a `compose.yaml`, to spin up a Home Assistant stable version where developers can test their changes. This method is optional, so developers can still test the way they want their changes.

### Testing:

Start the container through `docker compose up -d` and install the integration as you would normally do.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
