### PR TITLE
deps: update econnect-python to 0.9.1

### DIFF
--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -15,7 +15,7 @@
     "custom_components.econnect_metronet"
   ],
   "requirements": [
-    "econnect-python==0.9.0"
+    "econnect-python==0.9.1"
   ],
   "version": "2.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.9.0",
+  "econnect-python==0.9.1",
   "homeassistant",
 ]
 


### PR DESCRIPTION
### Related Issues

- Closes https://github.com/palazzem/ha-econnect-alarm/issues/115

### Proposed Changes:

This update refines the `query()` method in the client, which fetches synchronized data between the main unit and the cloud (using `_get_descriptions()` under the hood). Issues arise when strings are not in sync, specifically when:
1. The central unit has defined and `InUse` outputs, inputs, or sectors.
2. The cloud is not in sync, leading to missing keys (9, 10, or 12) in `_get_descriptions()`, causing a `KeyError`.

To address this, we've implemented a safer access via the dictionary `get()` method. Now, if a string is missing, `Unknown` is returned instead of an error.

### Testing:

Test with a central unit where an output is `InUse`, but no strings are configured in the cloud.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
