### PR TITLE
deps: add `async_timeout` package used in the `AlarmCoordinator`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 ]
 dependencies = [
   "econnect-python==0.9.1",
+  "async_timeout",
   "homeassistant",
 ]
 


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->

Includes `async_timeout` in the dependency list. This dependency is automatically included in Home Assistant, but as this project is a standalone project, this dependency is required.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
