### PR TITLE
fix: `econnect-python` logger can be enabled from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ homekit:
 
 Please note that Apple Home requires you to confirm automations that involves security devices such as lockers and alarm systems.
 
+## Troubleshooting
+
+If you encounter an issue, providing `DEBUG` logs can greatly assist us in identifying the bug. Please follow these steps to send us the debug logs:
+
+1. Navigate to the integration configuration page in Home Assistant: **Settings > Devices & Services > e-Connect/Metronet Alarm**.
+2. Enable debug logging by clicking on **Enable debug logging**.
+3. Restart the integration by selecting **Restart** from the three-dot menu.
+4. Reproduce the error (e.g., arm the system or modify the configuration).
+5. After reproducing the error, return to the Integration configuration page and click **Disable debug logging**.
+6. Your browser will prompt you to download the log file.
+7. Ensure that the logs do not contain sensitive information, as we do not log credentials or access tokens.
+8. Send the logs to us via a secure method. **Do not post your logs on public platforms** like our Discord general channel or GitHub issues, as they are publicly accessible.
+
+<img src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/08e5dc92-6b0e-4f41-bab0-e1851405425b">
 
 ## Contributing
 

--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -12,7 +12,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/palazzem/ha-econnect-alarm/issues",
   "loggers": [
-    "custom_components.econnect_metronet"
+    "custom_components.econnect_metronet",
+    "elmo"
   ],
   "requirements": [
     "econnect-python==0.9.1"


### PR DESCRIPTION
### Related Issues

- Closes #122 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds `econnect-python` logger (`elmo`) to the integration `manifest.json` so that all loggers can be enabled directly from the UI.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Activate it from the Integration configuration page:

<img width="1034" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/08e5dc92-6b0e-4f41-bab0-e1851405425b">

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
