### PR TITLE
fix(config): `domain` field is required and pre-filled with `default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ If you are curious about the project and want to know more, check out our [Disco
 - Username: is your username to access Elmo/IESS via web or app.
 - Password: is your password to access Elmo/IESS via web or app.
 - System: pick the brand of alarm system you are using.
-- Domain name (optional): domain used to access your login page via web. For instance, if you access to `https://connect.elmospa.com/vendor/`,
-  you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.
+- Domain name: domain used to access your login page via web. If you access to `https://connect.elmospa.com/vendor/`,
+  you must set the domain to `vendor`. In case you don't have a vendor defined, leave it to `default`.
 
 ### Options
 

--- a/custom_components/econnect_metronet/config_flow.py
+++ b/custom_components/econnect_metronet/config_flow.py
@@ -69,7 +69,7 @@ class EconnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
                 return self.async_create_entry(title="e-Connect/Metronet Alarm", data=user_input)
 
         # Populate with latest changes
-        user_input = user_input or {}
+        user_input = user_input or {CONF_DOMAIN: "default"}
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -87,7 +87,7 @@ class EconnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
                         default=E_CONNECT_DEFAULT,
                         description={"suggested_value": user_input.get(CONF_SYSTEM_URL)},
                     ): vol.In(SUPPORTED_SYSTEMS),
-                    vol.Optional(
+                    vol.Required(
                         CONF_DOMAIN,
                         description={"suggested_value": user_input.get(CONF_DOMAIN)},
                     ): str,

--- a/custom_components/econnect_metronet/strings.json
+++ b/custom_components/econnect_metronet/strings.json
@@ -3,12 +3,12 @@
         "step": {
             "user": {
                 "data": {
-                    "domain": "Domain name (optional)",
+                    "domain": "Domain name",
                     "username": "[%key:common::config_flow::data::username%]",
                     "password": "[%key:common::config_flow::data::password%]",
                     "system_name": "[%key:common::config_flow::data::system_name%]"
                 },
-                "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
+                "description": "Provide your credentials and the domain used to access your login page via web.\n\nIf you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, leave it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
                 "title": "Configure your Elmo/IESS system"
             }
         },

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -12,12 +12,12 @@
         "step": {
             "user": {
                 "data": {
-                    "domain": "Domain name (optional)",
+                    "domain": "Domain name",
                     "username": "Username",
                     "password": "Password",
                     "system_name": "Name of the control panel (optional)"
                 },
-                "description": "Provide your credentials and the domain used to access your login page via web.\n\nFor instance, if you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, set it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
+                "description": "Provide your credentials and the domain used to access your login page via web.\n\nIf you access to `https://connect.elmospa.com/vendor/`, you must set the domain to `vendor`. In case you don't have a vendor defined, leave it to `default`.\n\nYou can configure the system selecting \"Options\" after installing the integration.",
                 "title": "Configure your e-Connect/Metronet system"
             }
         }

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -12,12 +12,12 @@
         "step": {
             "user": {
                 "data": {
-                    "domain": "Nome dominio (opzionale)",
+                    "domain": "Nome dominio",
                     "username": "Nome utente",
                     "password": "Password",
                     "system_name": "Nome dell'impianto (opzionale)"
                 },
-                "description": "Fornisci le tue credenziali e il dominio utilizzato per accedere alla tua pagina di login via web.\n\nAd esempio, se accedi a `https://connect.elmospa.com/installatore/`, devi impostare il dominio su `installatore`. Nel caso in cui non hai un installatore definito, impostalo su `default`.\n\nPuoi configurare il sistema selezionando \"Opzioni\" dopo aver installato l'integrazione.",
+                "description": "Fornisci le tue credenziali e il dominio utilizzato per accedere alla tua pagina di login via web.\n\nSe accedi a `https://connect.elmospa.com/installatore/`, devi impostare il dominio su `installatore`. Nel caso in cui tu non abbia un installatore impostato, lascia il valore su `default`.\n\nPuoi configurare il sistema selezionando \"Opzioni\" dopo aver installato l'integrazione.",
                 "title": "Configura il tuo sistema e-Connect/Metronet"
             }
         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -33,14 +33,14 @@ async def test_form_submit_successful_with_input(hass, mocker):
         {
             "username": "test-username",
             "password": "test-password",
-            "domain": "test-domain",
+            "domain": "default",
             "system_base_url": "https://metronet.iessonline.com",
         },
     )
     await hass.async_block_till_done()
     # Check Client Authentication
     assert m_client.call_args.args == ("https://metronet.iessonline.com",)
-    assert m_client.call_args.kwargs == {"domain": "test-domain"}
+    assert m_client.call_args.kwargs == {"domain": "default"}
     assert m_client().auth.call_count == 1
     assert m_client().auth.call_args.args == ("test-username", "test-password")
     # Check HA setup
@@ -51,7 +51,7 @@ async def test_form_submit_successful_with_input(hass, mocker):
     assert result["data"] == {
         "username": "test-username",
         "password": "test-password",
-        "domain": "test-domain",
+        "domain": "default",
         "system_base_url": "https://metronet.iessonline.com",
     }
 
@@ -68,6 +68,7 @@ async def test_form_submit_with_defaults(hass, mocker):
         {
             "username": "test-username",
             "password": "test-password",
+            "domain": "default",
         },
     )
     await hass.async_block_till_done()
@@ -76,11 +77,12 @@ async def test_form_submit_with_defaults(hass, mocker):
     assert result["data"] == {
         "username": "test-username",
         "password": "test-password",
+        "domain": "default",
         "system_base_url": "https://connect.elmospa.com",
     }
     # Check Client Authentication
     assert m_client.call_args.args == ("https://connect.elmospa.com",)
-    assert m_client.call_args.kwargs == {"domain": None}
+    assert m_client.call_args.kwargs == {"domain": "default"}
     assert m_client().auth.call_count == 1
     assert m_client().auth.call_args.args == ("test-username", "test-password")
     # Check HA setup
@@ -108,12 +110,14 @@ async def test_form_submit_required_fields(hass, mocker):
     with pytest.raises(MultipleInvalid) as excinfo:
         await hass.config_entries.flow.async_configure(form["flow_id"], {})
     await hass.async_block_till_done()
-    assert len(excinfo.value.errors) == 2
+    assert len(excinfo.value.errors) == 3
     errors = []
     errors.append(str(excinfo.value.errors[0]))
     errors.append(str(excinfo.value.errors[1]))
+    errors.append(str(excinfo.value.errors[2]))
     assert "required key not provided @ data['username']" in errors
     assert "required key not provided @ data['password']" in errors
+    assert "required key not provided @ data['domain']" in errors
 
 
 async def test_form_submit_wrong_credential(hass, mocker):


### PR DESCRIPTION
### Related Issues

- Closes #119 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Makes `domain` required during the installation step, forcing users to insert a value. By default, the field is prefilled with `default` that should work for all users without a vendor.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Install the integration and check the installation page.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
