### PR TITLE
fix(log): forcing a full update is not considered an error

### DIFF
--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -59,7 +59,7 @@ class AlarmCoordinator(DataUpdateCoordinator):
                     # the long-polling strategy. If IDs are misaligned, then no updates happen and
                     # the integration remains stuck.
                     # See: https://github.com/palazzem/ha-econnect-alarm/issues/51
-                    _LOGGER.error("Coordinator | Central unit disconnected, forcing a full update")
+                    _LOGGER.debug("Coordinator | Central unit disconnected, forcing a full update")
                     return await self.hass.async_add_executor_job(self._device.update)
 
                 # `device.has_updates` implements e-Connect long-polling API. This


### PR DESCRIPTION
### Related Issues

- #121 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Changes debug level from `ERROR` to `DEBUG` when a full update is required.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
 This partially solves the issue in #121 where, in some cases, sensors can still be detected as unavailable. For further improvements, we should rewrite the `AlarmCoordinator` logic as  we may need to handle updates differently.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
