### PR TITLE
fix: set `CONFIG_SCHEMA` to accept configuration from config entries

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -7,6 +7,7 @@ from elmo.api.client import ElmoClient
 from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
 from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 
 from .const import (
     CONF_DOMAIN,
@@ -23,6 +24,7 @@ from .devices import AlarmDevice
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 PLATFORMS = ["alarm_control_panel", "binary_sensor", "sensor", "switch"]
 
 


### PR DESCRIPTION
### Related Issues

- Closes #19 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Sets `CONFIG_SCHEMA` to accept configuration from config entries. This change is not tested as `hassfest` workflow does the check to be sure it's set.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
