### PR TITLE
fix(device): disarm only currently activated sectors to support users with limited permissions

### DIFF
--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -322,6 +322,10 @@ class AlarmDevice:
             else:
                 user_id = None
 
+            # Detect which sectors should be disarmed
+            if sectors is None:
+                sectors = [sector["element"] for _, sector in self.items(q.SECTORS, status=True)]
+
             with self._connection.lock(code, user_id=user_id):
                 self._connection.disarm(sectors=sectors)
                 self.state = STATE_ALARM_DISARMED

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -296,7 +296,7 @@ class AlarmDevice:
             if not self.panel.get("login_without_user_id", True):
                 user_id, code = split_code(code)
             else:
-                user_id = None
+                user_id = 1
 
             with self._connection.lock(code, user_id=user_id):
                 self._connection.arm(sectors=sectors)
@@ -320,7 +320,7 @@ class AlarmDevice:
             if not self.panel.get("login_without_user_id", True):
                 user_id, code = split_code(code)
             else:
-                user_id = None
+                user_id = 1
 
             # Detect which sectors should be disarmed
             if sectors is None:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1185,7 +1185,7 @@ def test_device_arm_success_user_id_not_required(alarm_device, mocker):
     assert alarm_device._connection.lock.call_count == 1
     assert alarm_device._connection.arm.call_count == 1
     assert "123456" in alarm_device._connection.lock.call_args[0]
-    assert {"user_id": None} == alarm_device._connection.lock.call_args[1]
+    assert {"user_id": 1} == alarm_device._connection.lock.call_args[1]
     assert {"sectors": [4]} == alarm_device._connection.arm.call_args[1]
 
 
@@ -1295,7 +1295,7 @@ def test_device_disarm_success_user_id_not_required(alarm_device, mocker):
     assert alarm_device._connection.lock.call_count == 1
     assert alarm_device._connection.disarm.call_count == 1
     assert "123456" in alarm_device._connection.lock.call_args[0]
-    assert {"user_id": None} == alarm_device._connection.lock.call_args[1]
+    assert {"user_id": 1} == alarm_device._connection.lock.call_args[1]
     assert {"sectors": [4]} == alarm_device._connection.disarm.call_args[1]
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1256,6 +1256,20 @@ def test_device_disarm_success(alarm_device, mocker):
     assert {"sectors": [4]} == alarm_device._connection.disarm.call_args[1]
 
 
+def test_device_disarm_activated_sectors(alarm_device, mocker):
+    """Should disarm sectors that are currently activated if no sectors are specified."""
+    mocker.spy(alarm_device._connection, "lock")
+    mocker.spy(alarm_device._connection, "disarm")
+    # Test
+    alarm_device._connection._session_id = "test"
+    alarm_device.disarm("1234")
+
+    assert alarm_device._connection.lock.call_count == 1
+    assert alarm_device._connection.disarm.call_count == 1
+    assert "1234" in alarm_device._connection.lock.call_args[0]
+    assert {"sectors": [1, 2]} == alarm_device._connection.disarm.call_args[1]
+
+
 def test_device_disarm_success_without_panel_details(alarm_device, mocker):
     """Should assume `userId` is not required if panel details are empty."""
     alarm_device._inventory = {}


### PR DESCRIPTION
### Related Issues

- Closes #123 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Instead of disarming all sectors, the `AlarmDevice` disarms only the currently activated sector. This change is a no-op for users as it is expected that disarming activated sectors is the same as disarming all. Instead, it's a fix for all users that have accounts with limited permissions and multiple areas, that can't use the disarm all (see #123).

A race condition may be introduced with this change if:
- Sectors 1, 2 are activated
- The device updates the internal state and 1, 2 are now considered activated
- From an external tool (e.g. BrowserOne or web UI) we enable also sector 3
- We immediately disarm the system before the device updates the internal state

This race condition is an edge case that we consider negligible as it requires too many steps. Furthermore, the device will update the state anyway, going back to an armed state that can disable the sector 3.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Arm and disarm a system.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
