### PR TITLE
fix(config): `experimental` settings are enabled again as internal config

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -3,11 +3,11 @@
 import asyncio
 import logging
 
+import voluptuous as vol
 from elmo.api.client import ElmoClient
 from elmo.systems import ELMO_E_CONNECT as E_CONNECT_DEFAULT
 from homeassistant.config_entries import ConfigEntry, ConfigType
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 
 from .const import (
     CONF_DOMAIN,
@@ -24,7 +24,21 @@ from .devices import AlarmDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+# Allow experimental settings to be exposed in the YAML configuration
+# This part will be removed once the experimental settings are stable
+# and moved to the configuration flow. This is considered an internal
+# API so it will be removed without notice.
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Optional("experimental"): vol.Schema({}, extra=vol.ALLOW_EXTRA),
+            }
+        ),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
 PLATFORMS = ["alarm_control_panel", "binary_sensor", "sensor", "switch"]
 
 


### PR DESCRIPTION
### Related Issues

- #19 
- #131

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
The change made in #131 temporarily disabled `experimental` settings in the `configurations.yaml`. With this change we enable them again. We also remember that experimental settings are an internal API and such keys will be removed without notice. Indeed, Home Assistant discourages integrations to use YAML configurations, hence why users should not use these.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
