### PR TITLE
tests: use new `InvalidData` exception (HASS testing)

### DIFF
--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,6 +1,6 @@
 import pytest
+from homeassistant.data_entry_flow import InvalidData
 from homeassistant.helpers.config_validation import multi_select as select
-from voluptuous.error import MultipleInvalid
 
 from custom_components.econnect_metronet.const import DOMAIN, KEY_DEVICE
 
@@ -64,7 +64,7 @@ class TestOptionsFlow:
             config_entry.entry_id, context={"show_advanced_options": False}
         )
         # Test
-        with pytest.raises(MultipleInvalid) as excinfo:
+        with pytest.raises(InvalidData) as excinfo:
             await hass.config_entries.options.async_configure(
                 form["flow_id"],
                 user_input={
@@ -72,7 +72,7 @@ class TestOptionsFlow:
                 },
             )
             await hass.async_block_till_done()
-        assert excinfo.value.errors[0].msg == "Not a list"
+        assert excinfo.value.schema_errors["areas_arm_home"] == "Not a list"
 
     async def test_form_submit_invalid_input(self, hass, config_entry):
         # Ensure it fails if a user submits an option not in the allowed list
@@ -80,7 +80,7 @@ class TestOptionsFlow:
             config_entry.entry_id, context={"show_advanced_options": False}
         )
         # Test
-        with pytest.raises(MultipleInvalid) as excinfo:
+        with pytest.raises(InvalidData) as excinfo:
             await hass.config_entries.options.async_configure(
                 form["flow_id"],
                 user_input={
@@ -90,7 +90,7 @@ class TestOptionsFlow:
                 },
             )
             await hass.async_block_till_done()
-        assert excinfo.value.errors[0].msg == "(3, 'Garden') is not a valid option"
+        assert excinfo.value.schema_errors["areas_arm_home"] == "(3, 'Garden') is not a valid option"
 
     async def test_form_submit_successful_with_identifier(self, hass, config_entry):
         # Ensure users can submit an option just by using the option ID


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Uses `InvalidData` exception in tests. This is required to test newer Home Assistant versions.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
