### PR TITLE
feat: add arm/disarm sectors services to activate/deactivate a selection of sectors

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -186,6 +186,9 @@ class SectorBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._unique_id = unique_id
         self._sector_id = sector_id
 
+        # Register the sector with the device
+        device._register_sector(self)
+
     @property
     def unique_id(self) -> str:
         """Return the unique identifier."""

--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import (
 from .const import (
     CONF_EXPERIMENTAL,
     CONF_FORCE_UPDATE,
+    DEVICE_CLASS_SECTORS,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_DEVICE,
@@ -189,6 +190,11 @@ class SectorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def unique_id(self) -> str:
         """Return the unique identifier."""
         return self._unique_id
+
+    @property
+    def device_class(self) -> str:
+        """Return the device class."""
+        return DEVICE_CLASS_SECTORS
 
     @property
     def name(self) -> str:

--- a/custom_components/econnect_metronet/const.py
+++ b/custom_components/econnect_metronet/const.py
@@ -14,6 +14,7 @@ CONF_AREAS_ARM_HOME = "areas_arm_home"
 CONF_AREAS_ARM_NIGHT = "areas_arm_night"
 CONF_AREAS_ARM_VACATION = "areas_arm_vacation"
 CONF_SCAN_INTERVAL = "scan_interval"
+DEVICE_CLASS_SECTORS = "sector"
 DOMAIN = "econnect_metronet"
 NOTIFICATION_MESSAGE = (
     "The switch cannot be used because it requires two settings to be configured in the Alarm Panel: "

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -49,6 +49,7 @@ class AlarmDevice:
     def __init__(self, connection, config=None):
         # Configuration and internals
         self._inventory = {}
+        self._sectors = {}
         self._connection = connection
         self._last_ids = {
             q.SECTORS: 0,
@@ -66,6 +67,11 @@ class AlarmDevice:
 
         # Alarm state
         self.state = STATE_UNAVAILABLE
+
+    def _register_sector(self, entity):
+        """Register a sector entity in the device's internal inventory."""
+        entity_id = entity.entity_id.split(".")[1]
+        self._sectors[entity_id] = self._inventory[q.SECTORS][entity._sector_id]["element"]
 
     @property
     def panel(self):

--- a/custom_components/econnect_metronet/services.py
+++ b/custom_components/econnect_metronet/services.py
@@ -1,0 +1,38 @@
+import logging
+
+from elmo import query as q
+from homeassistant.core import HomeAssistant, ServiceCall
+
+from .const import DOMAIN, KEY_DEVICE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def arm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
+    _LOGGER.debug(f"Service | Triggered action {call.service}")
+    device = hass.data[DOMAIN][config_id][KEY_DEVICE]
+    registry = hass.data["binary_sensor"].entities.mapping
+    code = call.data.get("code")
+    # Retrieve sectors identifier (element) from provided entity ids
+    # NOTE: this step can be avoided if the entity_id mapping is stored in the device object
+    entities = [registry[entity] for entity in call.data["entity_id"]]
+    sectors = [
+        [item["element"] for id, item in device.items(q.SECTORS) if id == entity._sector_id] for entity in entities
+    ]
+    _LOGGER.debug(f"Service | Arming sectors: {sectors} with code {code})")
+    await hass.async_add_executor_job(device.arm, code, sectors)
+
+
+async def disarm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
+    _LOGGER.debug(f"Service | Triggered action {call.service}")
+    device = hass.data[DOMAIN][config_id][KEY_DEVICE]
+    registry = hass.data["binary_sensor"].entities.mapping
+    code = call.data.get("code")
+    # Retrieve sectors identifier (element) from provided entity ids
+    # NOTE: this step can be avoided if the entity_id mapping is stored in the device object
+    entities = [registry[entity] for entity in call.data["entity_id"]]
+    sectors = [
+        [item["element"] for id, item in device.items(q.SECTORS) if id == entity._sector_id] for entity in entities
+    ]
+    _LOGGER.debug(f"Service | Arming sectors: {sectors} with code {code})")
+    await hass.async_add_executor_job(device.disarm, code, sectors)

--- a/custom_components/econnect_metronet/services.py
+++ b/custom_components/econnect_metronet/services.py
@@ -1,6 +1,5 @@
 import logging
 
-from elmo import query as q
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN, KEY_DEVICE
@@ -11,14 +10,8 @@ _LOGGER = logging.getLogger(__name__)
 async def arm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
     _LOGGER.debug(f"Service | Triggered action {call.service}")
     device = hass.data[DOMAIN][config_id][KEY_DEVICE]
-    registry = hass.data["binary_sensor"].entities.mapping
+    sectors = [device._sectors[x.split(".")[1]] for x in call.data["entity_id"]]
     code = call.data.get("code")
-    # Retrieve sectors identifier (element) from provided entity ids
-    # NOTE: this step can be avoided if the entity_id mapping is stored in the device object
-    entities = [registry[entity] for entity in call.data["entity_id"]]
-    sectors = [
-        [item["element"] for id, item in device.items(q.SECTORS) if id == entity._sector_id] for entity in entities
-    ]
     _LOGGER.debug(f"Service | Arming sectors: {sectors} with code {code})")
     await hass.async_add_executor_job(device.arm, code, sectors)
 
@@ -26,13 +19,7 @@ async def arm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
 async def disarm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
     _LOGGER.debug(f"Service | Triggered action {call.service}")
     device = hass.data[DOMAIN][config_id][KEY_DEVICE]
-    registry = hass.data["binary_sensor"].entities.mapping
+    sectors = [device._sectors[x.split(".")[1]] for x in call.data["entity_id"]]
     code = call.data.get("code")
-    # Retrieve sectors identifier (element) from provided entity ids
-    # NOTE: this step can be avoided if the entity_id mapping is stored in the device object
-    entities = [registry[entity] for entity in call.data["entity_id"]]
-    sectors = [
-        [item["element"] for id, item in device.items(q.SECTORS) if id == entity._sector_id] for entity in entities
-    ]
     _LOGGER.debug(f"Service | Arming sectors: {sectors} with code {code})")
     await hass.async_add_executor_job(device.disarm, code, sectors)

--- a/custom_components/econnect_metronet/services.yaml
+++ b/custom_components/econnect_metronet/services.yaml
@@ -1,9 +1,13 @@
-# Describes the format for available alarm control panel services
+# Describes the format for available e-Connect services
 
-alarm_disarm:
-  name: Disarm
-  description: Send the alarm the command for disarm.
+arm_sectors:
+  name: Arm Sectors
+  description: Arm one or multiple sectors.
   target:
+    entity:
+      integration: econnect_metronet
+      domain: binary_sensor
+      device_class: "sector"
   fields:
     code:
       name: Code
@@ -13,62 +17,14 @@ alarm_disarm:
       selector:
         text:
 
-alarm_arm_custom_bypass:
-  name: Arm with custom bypass
-  description: Send arm custom bypass command.
+disarm_sectors:
+  name: Disarm Sectors
+  description: Disarm one or multiple sectors.
   target:
-  fields:
-    code:
-      name: Code
-      required: true
-      description: A code to trigger the alarm control panel with.
-      example: "1234"
-      selector:
-        text:
-
-alarm_arm_home:
-  name: Arm home
-  description: Send the alarm the command for arm home.
-  target:
-  fields:
-    code:
-      name: Code
-      required: true
-      description: A code to trigger the alarm control panel with.
-      example: "1234"
-      selector:
-        text:
-
-alarm_arm_away:
-  name: Arm away
-  description: Send the alarm the command for arm away.
-  target:
-  fields:
-    code:
-      name: Code
-      required: true
-      description: A code to trigger the alarm control panel with.
-      example: "1234"
-      selector:
-        text:
-
-alarm_arm_night:
-  name: Arm night
-  description: Send the alarm the command for arm night.
-  target:
-  fields:
-    code:
-      name: Code
-      required: true
-      description: A code to trigger the alarm control panel with.
-      example: "1234"
-      selector:
-        text:
-
-alarm_trigger:
-  name: Trigger
-  description: Send the alarm the command for trigger.
-  target:
+    entity:
+      integration: econnect_metronet
+      domain: binary_sensor
+      device_class: "sector"
   fields:
     code:
       name: Code

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -205,6 +205,12 @@ class TestInputBinarySensor:
 
 
 class TestSectorBinarySensor:
+    def test_binary_sensor_device_class(self, hass, config_entry, alarm_device):
+        # Ensure sectors provide the device class name
+        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
+        assert entity.device_class == "sector"
+
     def test_binary_sensor_input_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
 from requests.exceptions import HTTPError
 from requests.models import Response
 
+from custom_components.econnect_metronet.binary_sensor import SectorBinarySensor
 from custom_components.econnect_metronet.const import (
     CONF_AREAS_ARM_AWAY,
     CONF_AREAS_ARM_HOME,
@@ -27,6 +28,7 @@ def test_device_constructor(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
+    assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
     assert device._sectors_away == []
     assert device._sectors_home == []
@@ -47,6 +49,7 @@ def test_device_constructor_with_config(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
+    assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
     assert device._sectors_away == [1, 2, 3, 4, 5]
     assert device._sectors_home == [3, 4]
@@ -67,6 +70,7 @@ def test_device_constructor_with_config_empty(client):
     # Test
     assert device._connection == client
     assert device._inventory == {}
+    assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
     assert device._sectors_away == []
     assert device._sectors_home == []
@@ -1131,6 +1135,13 @@ def test_device_update_query_not_valid(client, mocker):
     device._connection.query.side_effect = Exception("Unexpected")
     # Test
     assert device.update() is None
+
+
+def test_device_register_sector(alarm_device, config_entry, coordinator):
+    # Ensure a sector can register itself so the device can map entity ids to sector codes
+    sector = SectorBinarySensor("test_id", 0, config_entry, "S1 Living Room", coordinator, alarm_device)
+    alarm_device._register_sector(sector)
+    assert alarm_device._sectors["econnect_metronet.econnect_metronet_test_user_s1_living_room"] == 1
 
 
 def test_device_arm_success(alarm_device, mocker):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1141,7 +1141,7 @@ def test_device_register_sector(alarm_device, config_entry, coordinator):
     # Ensure a sector can register itself so the device can map entity ids to sector codes
     sector = SectorBinarySensor("test_id", 0, config_entry, "S1 Living Room", coordinator, alarm_device)
     alarm_device._register_sector(sector)
-    assert alarm_device._sectors["econnect_metronet.econnect_metronet_test_user_s1_living_room"] == 1
+    assert alarm_device._sectors["econnect_metronet_test_user_s1_living_room"] == 1
 
 
 def test_device_arm_success(alarm_device, mocker):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,59 @@
+from homeassistant.core import ServiceCall
+
+from custom_components.econnect_metronet import services
+from custom_components.econnect_metronet.binary_sensor import SectorBinarySensor
+from custom_components.econnect_metronet.const import DOMAIN
+
+
+async def test_service_arm_sectors(hass, config_entry, alarm_device, coordinator, mocker):
+    # Ensure `arm_sectors` activates the correct sectors
+    arm = mocker.patch.object(alarm_device, "arm")
+    SectorBinarySensor("test_id", 0, config_entry, "S1 Living Room", coordinator, alarm_device)
+    SectorBinarySensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+    call = ServiceCall(
+        domain=DOMAIN,
+        service="arm_sectors",
+        data={
+            "entity_id": [
+                "binary_sensor.econnect_metronet_test_user_s1_living_room",
+                "binary_sensor.econnect_metronet_test_user_s3_outdoor",
+            ],
+            "code": "1234",
+        },
+    )
+    # Test
+    await services.arm_sectors(hass, config_entry.entry_id, call)
+    assert arm.call_count == 1
+    assert arm.call_args[0][0] == "1234"
+    assert arm.call_args[0][1] == [1, 3]
+
+
+async def test_service_disarm_sectors(hass, config_entry, alarm_device, coordinator, mocker):
+    # Ensure `disarm_sectors` activates the correct sectors
+    disarm = mocker.patch.object(alarm_device, "disarm")
+    SectorBinarySensor("test_id", 0, config_entry, "S1 Living Room", coordinator, alarm_device)
+    SectorBinarySensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+    call = ServiceCall(
+        domain=DOMAIN,
+        service="disarm_sectors",
+        data={
+            "entity_id": [
+                "binary_sensor.econnect_metronet_test_user_s1_living_room",
+                "binary_sensor.econnect_metronet_test_user_s3_outdoor",
+            ],
+            "code": "1234",
+        },
+    )
+    # Test
+    await services.disarm_sectors(hass, config_entry.entry_id, call)
+    assert disarm.call_count == 1
+    assert disarm.call_args[0][0] == "1234"
+    assert disarm.call_args[0][1] == [1, 3]


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Implements `arm_sectors` and `disarm_sectors` services that can be used to enable a single sector or a list of sectors. The change includes an internal mapping between sectors entity ids and the actual sector ID in the e-Connect backend API. While this change is not expected to stay, it is currently required as Home Assistant doesn't provide a way to easily access entities (see https://github.com/palazzem/ha-econnect-alarm/commit/b16d1190771ccef5b301cf11bab75329d7057ce2#diff-9228969e4ac379606b6ced4a4f29bcacc8c5cf55b2a94c47721038593dab9557R11-R23).

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Open the developer console and simply activate/deactivate sectors (or use it within automations).

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
A refactoring of `AlarmDevice` is required regardless, so we don't need to overcomplicate this implementation as interfaces will change eventually.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
