### PR TITLE
fix: add missing icons for registered services

### DIFF
--- a/custom_components/econnect_metronet/icons.json
+++ b/custom_components/econnect_metronet/icons.json
@@ -1,0 +1,6 @@
+{
+    "services": {
+        "arm_sectors": "mdi:shield-lock",
+        "disarm_sectors": "mdi:shield-off"
+    }
+}


### PR DESCRIPTION
### Related Issues

- Related to #144 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add missing icons for registered services:

<img width="340" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/d6e59220-d90b-4208-a23c-6228d772a2f9">


### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
