### PR TITLE
feat(experimental): add managed sectors to control only part of available areas

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from . import services
 from .const import (
     CONF_DOMAIN,
+    CONF_EXPERIMENTAL,
     CONF_SCAN_INTERVAL,
     CONF_SYSTEM_URL,
     DOMAIN,
@@ -102,9 +103,15 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     Raises:
         Any exceptions raised by the coordinator or the setup process will be propagated up to the caller.
     """
+    # Enable experimental settings from the configuration file
+    # NOTE: While it's discouraged to use YAML configurations for integrations, this approach
+    # ensures that we can experiment with new settings we can break without notice.
+    experimental = hass.data[DOMAIN].get(CONF_EXPERIMENTAL, {})
+
+    # Initialize Components
     scan_interval = config.options.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
     client = ElmoClient(config.data[CONF_SYSTEM_URL], config.data[CONF_DOMAIN])
-    device = AlarmDevice(client, config.options)
+    device = AlarmDevice(client, {**config.options, **experimental})
     coordinator = AlarmCoordinator(hass, device, scan_interval)
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/econnect_metronet/const.py
+++ b/custom_components/econnect_metronet/const.py
@@ -14,6 +14,7 @@ CONF_AREAS_ARM_HOME = "areas_arm_home"
 CONF_AREAS_ARM_NIGHT = "areas_arm_night"
 CONF_AREAS_ARM_VACATION = "areas_arm_vacation"
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_MANAGE_SECTORS = "managed_sectors"
 DEVICE_CLASS_SECTORS = "sector"
 DOMAIN = "econnect_metronet"
 NOTIFICATION_MESSAGE = (

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -18,6 +18,7 @@ from custom_components.econnect_metronet.const import (
     CONF_AREAS_ARM_HOME,
     CONF_AREAS_ARM_NIGHT,
     CONF_AREAS_ARM_VACATION,
+    CONF_MANAGE_SECTORS,
 )
 from custom_components.econnect_metronet.devices import AlarmDevice
 
@@ -30,6 +31,7 @@ def test_device_constructor(client):
     assert device._inventory == {}
     assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
+    assert device._managed_sectors == []
     assert device._sectors_away == []
     assert device._sectors_home == []
     assert device._sectors_night == []
@@ -44,6 +46,7 @@ def test_device_constructor_with_config(client):
         CONF_AREAS_ARM_HOME: [3, 4],
         CONF_AREAS_ARM_NIGHT: [1, 2, 3],
         CONF_AREAS_ARM_VACATION: [5, 3],
+        CONF_MANAGE_SECTORS: [1, 2, 3, 4, 5],
     }
     device = AlarmDevice(client, config=config)
     # Test
@@ -51,6 +54,7 @@ def test_device_constructor_with_config(client):
     assert device._inventory == {}
     assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
+    assert device._managed_sectors == [1, 2, 3, 4, 5]
     assert device._sectors_away == [1, 2, 3, 4, 5]
     assert device._sectors_home == [3, 4]
     assert device._sectors_night == [1, 2, 3]
@@ -65,6 +69,7 @@ def test_device_constructor_with_config_empty(client):
         CONF_AREAS_ARM_HOME: None,
         CONF_AREAS_ARM_NIGHT: None,
         CONF_AREAS_ARM_VACATION: None,
+        CONF_MANAGE_SECTORS: None,
     }
     device = AlarmDevice(client, config=config)
     # Test
@@ -72,6 +77,7 @@ def test_device_constructor_with_config_empty(client):
     assert device._inventory == {}
     assert device._sectors == {}
     assert device._last_ids == {10: 0, 9: 0, 11: 0, 12: 0}
+    assert device._managed_sectors == []
     assert device._sectors_away == []
     assert device._sectors_home == []
     assert device._sectors_night == []
@@ -576,6 +582,17 @@ def test_device_inventory_update_success(client, mocker):
     # Test
     device.update()
     assert device._inventory == inventory
+
+
+def test_device_inventory_update_managed_sectors(alarm_device):
+    # Ensure that only managed sectors are updated
+    alarm_device._managed_sectors = [2, 3]
+    # Test
+    alarm_device.update()
+    assert alarm_device._inventory[q.SECTORS] == {
+        1: {"element": 2, "activable": True, "id": 2, "index": 1, "name": "S2 Bedroom", "status": True},
+        2: {"element": 3, "activable": False, "id": 3, "index": 2, "name": "S3 Outdoor", "status": False},
+    }
 
 
 class TestInputsView:


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Provides an internal configuration to manage only a subset of possible sectors. This is useful if the alarm panel should not take into consideration some sectors, meaning it will consider itself "Disarmed" even if some sectors are activated.

**WARNING**: This change is `experimental`, meaning it will be removed without deprecation notice.

### Usage
Add the following to your `configuration.yaml`:
```yaml
econnect_metronet:
  experimental:
    managed_sectors: [1, 2, 4]
```

Note that `[1, 2, 4]` must always be a list, and it must match the number of your sectors. An empty list, or a missing configuration, means that all sectors are managed.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Add the configuration as described above. You should see some sectors "Unavailable".

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
