### PR TITLE
tests: disable DEBUG log level when `pytest` is launched with `--verbose`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import responses
 from elmo.api.client import ElmoClient
@@ -13,6 +15,18 @@ from .fixtures import responses as r
 from .helpers import MockConfigEntry
 
 pytest_plugins = ["tests.hass.fixtures"]
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Keeps the default log level to WARNING.
+
+    Home Assistant sets the log level to `DEBUG` if the `--verbose` flag is used.
+    Considering all the debug logs of this integration and `econnect-python`, this is very
+    noisy. This is an override for `tests/hass/fixtures.py` as described in this
+    issue: https://github.com/palazzem/ha-econnect-alarm/issues/134
+    """
+    if config.getoption("verbose") > 0:
+        logging.getLogger().setLevel(logging.WARNING)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Related Issues

- Closes #134 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Overrides `pytest_configure()` that is defined in HA fixtures.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
If a test fails, DEBUG logs should not be printed.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
