### PR TITLE
fix(collector): return previous states when the device is disconnected

### DIFF
--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -88,5 +88,5 @@ class AlarmCoordinator(DataUpdateCoordinator):
             # to make all entities unavailable for a temporary issue. Furthermore, if the device goes
             # in an unavailable state, it might trigger unwanted automations.
             # See: https://github.com/palazzem/ha-econnect-alarm/issues/148
-            _LOGGER.error(f"Coordinator | {err}, keeping the previous state")
+            _LOGGER.error(f"Coordinator | {err}. Keeping the last known state.")
             return {}

--- a/custom_components/econnect_metronet/coordinator.py
+++ b/custom_components/econnect_metronet/coordinator.py
@@ -53,7 +53,7 @@ class AlarmCoordinator(DataUpdateCoordinator):
                 return await self.hass.async_add_executor_job(self._device.update)
 
             async with async_timeout.timeout(POLLING_TIMEOUT):
-                if not self.last_update_success:
+                if not self.last_update_success or not self._device.connected:
                     # Force an update if at least one failed. This is required to prevent
                     # a misalignment between the `AlarmDevice` and backend IDs, needed to implement
                     # the long-polling strategy. If IDs are misaligned, then no updates happen and

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -207,7 +207,6 @@ class AlarmDevice:
             _LOGGER.error(f"Device | Error parsing the poll response: {err}")
             raise err
         except DeviceDisconnectedError as err:
-            _LOGGER.error(f"Device | Error while polling for updates: {err}")
             self.connected = False
             raise err
 
@@ -288,7 +287,6 @@ class AlarmDevice:
             _LOGGER.error(f"Device | Error during the update: {err}")
             raise err
         except DeviceDisconnectedError as err:
-            _LOGGER.error(f"Device | Error during the update: {err}")
             self.connected = False
             raise err
 

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -6,6 +6,7 @@ from elmo.api.exceptions import (
     CodeError,
     CommandError,
     CredentialError,
+    DeviceDisconnectedError,
     LockError,
     ParseError,
 )
@@ -49,6 +50,7 @@ class AlarmDevice:
 
     def __init__(self, connection, config=None):
         # Configuration and internals
+        self.connected = False
         self._inventory = {}
         self._sectors = {}
         self._connection = connection
@@ -170,6 +172,7 @@ class AlarmDevice:
         """
         try:
             self._connection.auth(username, password)
+            self.connected = True
         except HTTPError as err:
             _LOGGER.error(f"Device | Error while authenticating with e-Connect: {err}")
             raise err
@@ -194,12 +197,18 @@ class AlarmDevice:
         """
         try:
             self._connection.query(q.ALERTS)
-            return self._connection.poll({key: value for key, value in self._last_ids.items()})
+            data = self._connection.poll({key: value for key, value in self._last_ids.items()})
+            self.connected = True
+            return data
         except HTTPError as err:
             _LOGGER.error(f"Device | Error while polling for updates: {err.response.text}")
             raise err
         except ParseError as err:
             _LOGGER.error(f"Device | Error parsing the poll response: {err}")
+            raise err
+        except DeviceDisconnectedError as err:
+            _LOGGER.error(f"Device | Error while polling for updates: {err}")
+            self.connected = False
             raise err
 
     def get_state(self):
@@ -278,8 +287,13 @@ class AlarmDevice:
         except ParseError as err:
             _LOGGER.error(f"Device | Error during the update: {err}")
             raise err
+        except DeviceDisconnectedError as err:
+            _LOGGER.error(f"Device | Error during the update: {err}")
+            self.connected = False
+            raise err
 
         # Update the _inventory
+        self.connected = True
         self._inventory.update({q.SECTORS: sectors["sectors"]})
         self._inventory.update({q.INPUTS: inputs["inputs"]})
         self._inventory.update({q.OUTPUTS: outputs["outputs"]})

--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -16,7 +16,7 @@
     "elmo"
   ],
   "requirements": [
-    "econnect-python==0.11.0"
+    "econnect-python==0.12.0a0"
   ],
   "version": "2.3.0"
 }

--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -16,7 +16,7 @@
     "elmo"
   ],
   "requirements": [
-    "econnect-python==0.12.0a0"
+    "econnect-python==0.12.0a1"
   ],
   "version": "2.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.11.0",
+  "econnect-python==0.12.0a0",
   "async_timeout",
   "homeassistant",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.12.0a0",
+  "econnect-python==0.12.0a1",
   "async_timeout",
   "homeassistant",
 ]

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -27,6 +27,7 @@ def test_device_constructor(client):
     """Should initialize defaults attributes to run properly."""
     device = AlarmDevice(client)
     # Test
+    assert device.connected is False
     assert device._connection == client
     assert device._inventory == {}
     assert device._sectors == {}
@@ -50,6 +51,7 @@ def test_device_constructor_with_config(client):
     }
     device = AlarmDevice(client, config=config)
     # Test
+    assert device.connected is False
     assert device._connection == client
     assert device._inventory == {}
     assert device._sectors == {}
@@ -73,6 +75,7 @@ def test_device_constructor_with_config_empty(client):
     }
     device = AlarmDevice(client, config=config)
     # Test
+    assert device.connected is False
     assert device._connection == client
     assert device._inventory == {}
     assert device._sectors == {}
@@ -364,6 +367,7 @@ def test_device_connect(client, mocker):
     assert device._connection.auth.call_count == 1
     assert "username" == device._connection.auth.call_args[0][0]
     assert "password" == device._connection.auth.call_args[0][1]
+    assert device.connected is True
 
 
 def test_device_connect_error(client, mocker):
@@ -375,6 +379,7 @@ def test_device_connect_error(client, mocker):
     with pytest.raises(HTTPError):
         device.connect("username", "password")
     assert device._connection.auth.call_count == 1
+    assert device.connected is False
 
 
 def test_device_connect_credential_error(client, mocker):
@@ -386,6 +391,7 @@ def test_device_connect_credential_error(client, mocker):
     with pytest.raises(CredentialError):
         device.connect("username", "password")
     assert device._connection.auth.call_count == 1
+    assert device.connected is False
 
 
 def test_device_has_updates(client, mocker):


### PR DESCRIPTION
### Related Issues

- Fixes #148 

### Proposed Changes

**Context:** This update enhances the `AlarmCoordinator` by enabling it to handle device disconnections during state polling and updates more gracefully. 

**Problem Solved:** Previously, a device disconnection led to all binary sensors entering an "Unavailable" state, potentially triggering undesired automations, including false alarm activations. To mitigate this, the update allows the `AlarmCoordinator` to retain the device's last known state instead of defaulting to "Unavailable" during brief disconnections.

**Implementation Details:** 
- The `AlarmDevice` now monitors the connection status through a new `device.connected` attribute. 
- This attribute is automatically refreshed once the device reconnects, ensuring the system accurately reflects the current state.

### Testing
- **Approach:** To validate the changes, manually disconnect the device and observe the logs for the expected behavior.
- **Expected Outcome:** The binary sensors should maintain their last state instead of showing as "Unavailable".

### Extra Notes
- **Feedback Mechanism:** This implementation does not yet offer a direct way to visually confirm the device's connection status outside of log entries. Consequently, implementing issue #139 becomes critical to provide a more intuitive feedback mechanism for users.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
