### PR TITLE
feat(entity): add connection status binary sensor to provide feedback in case of a disconnection

### DIFF
--- a/custom_components/econnect_metronet/binary_sensor.py
+++ b/custom_components/econnect_metronet/binary_sensor.py
@@ -54,6 +54,10 @@ async def async_setup_entry(
             unique_id = f"{entry.entry_id}_{DOMAIN}_{name}"
             sensors.append(AlertBinarySensor(unique_id, alert_id, entry, name, coordinator, device))
 
+    # Binary sensor to keep track of the device connection status
+    unique_id = f"{entry.entry_id}_{DOMAIN}_connection_status"
+    sensors.append(AlertBinarySensor(unique_id, -1, entry, "connection_status", coordinator, device))
+
     async_add_entities(sensors)
 
 

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -251,6 +251,11 @@ class AlarmDevice:
         Returns:
             int: The status of the item.
         """
+        if query == q.ALERTS and id == -1:
+            # Connection Status Alert
+            # NOTE: we should turn on the sensor (alert) if the device is not connected, hence the `not`
+            return not self.connected
+
         return self._inventory[query][id]["status"]
 
     def update(self):

--- a/custom_components/econnect_metronet/strings.json
+++ b/custom_components/econnect_metronet/strings.json
@@ -43,6 +43,13 @@
     },
     "entity": {
         "binary_sensor": {
+            "connection_status": {
+                "name": "Connection Status",
+                "state": {
+                    "on": "Disconnected",
+                    "off": "Connected"
+                }
+            },
             "anomalies_led": {
                 "name": "General Anomaly",
                 "state": {

--- a/custom_components/econnect_metronet/translations/en.json
+++ b/custom_components/econnect_metronet/translations/en.json
@@ -69,6 +69,13 @@
             }
         },
         "binary_sensor": {
+            "connection_status": {
+                "name": "Connection Status",
+                "state": {
+                    "on": "Disconnected",
+                    "off": "Connected"
+                }
+            },
             "anomalies_led": {
                 "name": "General Anomaly",
                 "state": {

--- a/custom_components/econnect_metronet/translations/it.json
+++ b/custom_components/econnect_metronet/translations/it.json
@@ -69,6 +69,13 @@
             }
         },
         "binary_sensor": {
+            "connection_status": {
+                "name": "Stato Connessione",
+                "state": {
+                    "on": "Disconnessa",
+                    "off": "Connessa"
+                }
+            },
             "anomalies_led": {
                 "name": "Anomalia Generale",
                 "state": {

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -22,9 +22,29 @@ async def test_async_setup_entry_in_use(hass, config_entry, alarm_device, coordi
 
     # Test
     def ensure_only_in_use(sensors):
-        assert len(sensors) == 28
+        assert len(sensors) == 29
 
     await async_setup_entry(hass, config_entry, ensure_only_in_use)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_connection_status(hass, config_entry, alarm_device, coordinator):
+    # Ensure the async setup loads the device connection status
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+
+    # Test
+    def check_connection_status(sensors):
+        connection_status = sensors[-1]
+        assert connection_status.unique_id == "test_entry_id_econnect_metronet_connection_status"
+        assert connection_status.entity_id == "econnect_metronet.econnect_metronet_test_user_connection_status"
+        assert connection_status.is_on is False
+        alarm_device.connected = False
+        assert connection_status.is_on is True
+
+    await async_setup_entry(hass, config_entry, check_connection_status)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Related Issues

- Closes #139 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change adds a binary sensor as a feedback mechanism in case the device is not connected to the Cloud API. You can use it to know if the state that you see is up to date, to trigger automations, to send notifications.

**Example:**
<img width="478" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/fed5ef2c-127e-432b-9652-efaf5e8bc99e">

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
1. Add the binary sensor to your dashboard.
2. The sensor should be `off` in case of connection.
3. Disconnect your main unit (device).
4. The sensor should be triggered.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
This is a follow-up PR for #148. With both changes, we keep the previous state in case of disconnection to avoid triggering unwanted automations, but at the same time we provide a good feedback mechanism.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
