### PR TITLE
fix(device): discard Cloud APIs empty states (connection resets)

### DIFF
--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -295,6 +295,12 @@ class AlarmDevice:
             self.connected = False
             raise err
 
+        # `last_id` equal to 1 means the connection has been reset and the update
+        # is an empty state. See: https://github.com/palazzem/ha-econnect-alarm/issues/148
+        if sectors.get("last_id") == 1:
+            _LOGGER.debug("Device | The connection has been reset, skipping the update")
+            return self._inventory
+
         # Update the _inventory
         self.connected = True
         self._inventory.update({q.SECTORS: sectors["sectors"]})


### PR DESCRIPTION
### Related Issues

- Follow-up #150 
- Closes #148 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change handles updates when a connection reset happens. In that case, the `last_id` is equal 1, meaning the Cloud API returns an empty state. With this change such updates are discarded and a full update is forced to reconcile the actual (cached) state, with the real one. 

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
1. Activate at least one sector
2. Disconnect the main unit
3. Wait the Integration to use a cached state (you should see errors in logs)
4. Reconnect the main unit
5. The integration must not change the alarm state (if the bug is present, it will go in "Disarmed" and then back to the actual state).

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
