### PR TITLE
fix(device): avoid state update while arming or disarming

### DIFF
--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -7,7 +7,9 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_ARMED_VACATION,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_DISARMING,
     STATE_UNAVAILABLE,
 )
 from requests.exceptions import HTTPError
@@ -1602,6 +1604,28 @@ def test_get_state_armed_away_with_config(alarm_device):
     }
     # Test
     assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY
+
+
+def test_get_state_while_disarming(alarm_device):
+    # Ensure that the state is not changed while disarming
+    # Regression test for: https://github.com/palazzem/ha-econnect-alarm/issues/154
+    alarm_device._sectors_home = []
+    alarm_device._sectors_night = []
+    alarm_device._inventory = {9: {}}
+    alarm_device.state = STATE_ALARM_DISARMING
+    # Test
+    assert alarm_device.get_state() == STATE_ALARM_DISARMING
+
+
+def test_get_state_while_arming(alarm_device):
+    # Ensure that the state is not changed while arming
+    # Regression test for: https://github.com/palazzem/ha-econnect-alarm/issues/154
+    alarm_device._sectors_home = []
+    alarm_device._sectors_night = []
+    alarm_device._inventory = {9: {}}
+    alarm_device.state = STATE_ALARM_ARMING
+    # Test
+    assert alarm_device.get_state() == STATE_ALARM_ARMING
 
 
 class TestTurnOff:


### PR DESCRIPTION
### Related Issues

- Closes #154 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change fixes a race condition that happens when the device arms the system, but before this happens an update is triggered and brings the system to a wrong state. Furthermore, avoids the `AlarmDevice` to set "Arm Away" wrong state.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
From "disarm", trigger the "arm home" state and be sure it doesn't transition back to "disarm", or in a wrong "arm away" state.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
This change creates a dependency between the `AlarmDevice` and the arm/disarm caller as it is expected who calls one of these methods, to set the right ending state. While this is not great and would be better to decouple it, it's a good enough solution. At some point, we may want to remove `AlarmDevice` transforming it in an actual entity.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
