### PR TITLE
fix(deprecation): use `async_update_entry` when handling config entries

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -54,8 +54,7 @@ async def async_migrate_entry(hass, config: ConfigEntry):
         migrated_config = {**config.data}
         # Migration
         migrated_config[CONF_SYSTEM_URL] = E_CONNECT_DEFAULT
-        config.version = 2
-        hass.config_entries.async_update_entry(config, data=migrated_config)
+        hass.config_entries.async_update_entry(config, data=migrated_config, minor_version=1, version=2)
 
     if config.version == 2:
         # Config initialization
@@ -63,13 +62,12 @@ async def async_migrate_entry(hass, config: ConfigEntry):
         options_to_migrate = ["areas_arm_home", "areas_arm_night", "areas_arm_vacation"]
         migrated_options = {}
         # Migration
-        config.version = 3
         for key, value in options.items():
             if key in options_to_migrate:
                 migrated_options[key] = [int(area) for area in value.split(",")]
             else:
                 migrated_options[key] = value
-        hass.config_entries.async_update_entry(config, options=migrated_options)
+        hass.config_entries.async_update_entry(config, options=migrated_options, minor_version=1, version=3)
 
     _LOGGER.info(f"Migration to version {config.version} successful")
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from custom_components.econnect_metronet.coordinator import AlarmCoordinator
 from custom_components.econnect_metronet.devices import AlarmDevice
 
 from .fixtures import responses as r
-from .helpers import MockConfigEntry
+from .hass.fixtures import MockConfigEntry
 
 pytest_plugins = ["tests.hass.fixtures"]
 
@@ -147,13 +147,13 @@ def client(socket_enabled):
 
 
 @pytest.fixture(scope="function")
-def config_entry():
+def config_entry(hass):
     """Creates a mock config entry for testing purposes.
 
     This config entry is designed to emulate the behavior of a real config entry for
     testing purposes.
     """
-    return MockConfigEntry(
+    config = MockConfigEntry(
         version=EconnectConfigFlow.VERSION,
         domain=DOMAIN,
         entry_id="test_entry_id",
@@ -165,3 +165,5 @@ def config_entry():
             "system_base_url": "https://example.com",
         },
     )
+    config.add_to_hass(hass)
+    return config

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,14 +1,3 @@
-from .hass.common import MockConfigEntry as BaseMockConfigEntry
-
-
-class MockConfigEntry(BaseMockConfigEntry):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Make settings overridable
-        self.data = kwargs.get("data", {})
-        self.options = kwargs.get("options", {})
-
-
 def _(mock_path: str) -> str:
     """Helper to simplify Mock path strings.
 

--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -17,7 +17,7 @@ def test_alarm_panel_name(client, hass, config_entry):
 
 def test_alarm_panel_name_with_system_name(client, hass, config_entry):
     # Ensure the Entity ID takes into consideration the system optional name
-    config_entry.data["system_name"] = "Home"
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     device = AlarmDevice(client)
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
@@ -34,7 +34,7 @@ def test_alarm_panel_entity_id(client, hass, config_entry):
 
 def test_alarm_panel_entity_id_with_system_name(client, hass, config_entry):
     # Ensure the Entity ID takes into consideration the system name
-    config_entry.data["system_name"] = "Home"
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     device = AlarmDevice(client)
     coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -135,7 +135,7 @@ class TestAlertBinarySensor:
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
@@ -148,7 +148,7 @@ class TestAlertBinarySensor:
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
@@ -181,7 +181,7 @@ class TestInputBinarySensor:
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
@@ -194,7 +194,7 @@ class TestInputBinarySensor:
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
@@ -239,7 +239,7 @@ class TestSectorBinarySensor:
 
     def test_binary_sensor_input_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
@@ -252,7 +252,7 @@ class TestSectorBinarySensor:
 
     def test_binary_sensor_input_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,29 +23,29 @@ def test_generate_entity_name_with_none(config_entry):
     assert valid_entity_id(entity_id)
 
 
-def test_generate_entity_name_empty_system(config_entry):
-    config_entry.data["system_name"] = "Home"
+def test_generate_entity_name_empty_system(hass, config_entry):
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     entity_id = generate_entity_id(config_entry)
     assert entity_id == "econnect_metronet.econnect_metronet_home"
     assert valid_entity_id(entity_id)
 
 
-def test_generate_entity_name_with_name_system(config_entry):
-    config_entry.data["system_name"] = "Home"
+def test_generate_entity_name_with_name_system(hass, config_entry):
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     entity_id = generate_entity_id(config_entry, "window")
     assert entity_id == "econnect_metronet.econnect_metronet_home_window"
     assert valid_entity_id(entity_id)
 
 
-def test_generate_entity_name_with_none_system(config_entry):
-    config_entry.data["system_name"] = "Home"
+def test_generate_entity_name_with_none_system(hass, config_entry):
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     entity_id = generate_entity_id(config_entry, None)
     assert entity_id == "econnect_metronet.econnect_metronet_home"
     assert valid_entity_id(entity_id)
 
 
-def test_generate_entity_name_with_spaces(config_entry):
-    config_entry.data["system_name"] = "Home Assistant"
+def test_generate_entity_name_with_spaces(hass, config_entry):
+    hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home Assistant"})
     entity_id = generate_entity_id(config_entry)
     assert entity_id == "econnect_metronet.econnect_metronet_home_assistant"
     assert valid_entity_id(entity_id)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,7 +1,7 @@
 from custom_components.econnect_metronet import async_migrate_entry
 from custom_components.econnect_metronet.const import DOMAIN
 
-from .helpers import MockConfigEntry
+from .hass.fixtures import MockConfigEntry
 
 
 async def test_async_no_migrations(mocker, hass, config_entry):
@@ -24,6 +24,7 @@ async def test_async_migrate_from_v1(hass):
             "domain": "econnect_metronet",
         },
     )
+    config_entry.add_to_hass(hass)
     # Test
     result = await async_migrate_entry(hass, config_entry)
     assert result is True
@@ -55,6 +56,7 @@ async def test_async_migrate_from_v2(hass):
             "system_base_url": "https://example.com",
         },
     )
+    config_entry.add_to_hass(hass)
     # Test
     result = await async_migrate_entry(hass, config_entry)
     assert result is True

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -59,7 +59,7 @@ class TestAlertSensor:
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.translation_key == "input_led"
@@ -72,7 +72,7 @@ class TestAlertSensor:
 
     def test_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_input_led"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -62,7 +62,7 @@ class TestOutputSwitch:
 
     def test_switch_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.name == "Output 2"
@@ -75,7 +75,7 @@ class TestOutputSwitch:
 
     def test_switch_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
-        config_entry.data["system_name"] = "Home"
+        hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
         coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_output_2"


### PR DESCRIPTION
### Related Issues

- Closes #156 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Config entries are updated using `async_update_entry` instead of using config attributes directly. In particular:
- Migrations don't use `config.version = 2` anymore
- Tests don't use a custom `MockConfigEntry` mock, in favor of the one provided by `hass.fixtures` (original HA fixtures)
- All tests are updated to use both the `MockConfigEntry` and `async_update_entry`

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
