### PR TITLE
feat: add support for Python 3.12

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Upgrade pip and install required tools
         run: |

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Upgrade pip and install required tools
         run: |

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -25,9 +25,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: |
+            3.11
+            3.12
 
       - name: Upgrade pip and install required tools
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     lint
     py3.11
+    py3.12
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
### Related Issues

- Closes #152 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Changes the test matrix to support the following Python versions:
- 3.11 (Home Assistant version < 2024.4)
- 3.12 (Home Assistant version 2024.4+)

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Run the testing matrix:
```bash
tox
```

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
