### PR TITLE
test(tox): use the right Python executable in tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     lint
-    py3.11
-    py3.12
+    python3.11
+    python3.12
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
### Related Issues

- n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Locally, Python 3.11 tests were skipped as `py3.11` executable is not found. This change uses the right python executable name (`python3.11`).

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
