### PR TITLE
fix(entity): retry all calls while refreshing the access token if expired

### DIFF
--- a/custom_components/econnect_metronet/decorators.py
+++ b/custom_components/econnect_metronet/decorators.py
@@ -34,6 +34,9 @@ def set_device_state(new_state, loader_state):
                 )
             except CodeError:
                 _LOGGER.warning("Inserted code is not correct. Retry.")
+            except Exception as err:
+                # All other exceptions are unexpected errors that must revert the state
+                _LOGGER.error(f"Device | Error during operation '{func.__name__}': {err}")
             # Reverting the state in case of any error
             self._device.state = previous_state
             self.async_write_ha_state()

--- a/custom_components/econnect_metronet/decorators.py
+++ b/custom_components/econnect_metronet/decorators.py
@@ -3,7 +3,10 @@
 import functools
 import logging
 
-from elmo.api.exceptions import CodeError, LockError
+from elmo.api.exceptions import CodeError, InvalidToken, LockError
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .const import DOMAIN, KEY_DEVICE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,3 +47,44 @@ def set_device_state(new_state, loader_state):
         return func_wrapper
 
     return decorator
+
+
+def retry_refresh_token(func):
+    @functools.wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        attempts = 0
+        while attempts < 2:
+            try:
+                return await func(self, *args, **kwargs)
+            except InvalidToken as err:
+                _LOGGER.debug(f"Device | Invalid access token: {err}")
+                if attempts < 1:
+                    username = self._config.data[CONF_USERNAME]
+                    password = self._config.data[CONF_PASSWORD]
+                    await self.hass.async_add_executor_job(self._device.connect, username, password)
+                    _LOGGER.debug("Device | Access token has been refreshed")
+                attempts += 1
+
+    return wrapper
+
+
+def retry_refresh_token_service(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        attempts = 0
+        while attempts < 2:
+            try:
+                return await func(*args, **kwargs)
+            except InvalidToken as err:
+                _LOGGER.debug(f"Device | Invalid access token: {err}")
+                if attempts < 1:
+                    hass, config_id, _ = args
+                    config = hass.config_entries.async_entries(DOMAIN)[0]
+                    device = hass.data[DOMAIN][config_id][KEY_DEVICE]
+                    username = config.data[CONF_USERNAME]
+                    password = config.data[CONF_PASSWORD]
+                    await hass.async_add_executor_job(device.connect, username, password)
+                    _LOGGER.debug("Device | Access token has been refreshed")
+                attempts += 1
+
+    return wrapper

--- a/custom_components/econnect_metronet/services.py
+++ b/custom_components/econnect_metronet/services.py
@@ -3,10 +3,12 @@ import logging
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN, KEY_DEVICE
+from .decorators import retry_refresh_token_service
 
 _LOGGER = logging.getLogger(__name__)
 
 
+@retry_refresh_token_service
 async def arm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
     _LOGGER.debug(f"Service | Triggered action {call.service}")
     device = hass.data[DOMAIN][config_id][KEY_DEVICE]
@@ -16,6 +18,7 @@ async def arm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
     await hass.async_add_executor_job(device.arm, code, sectors)
 
 
+@retry_refresh_token_service
 async def disarm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall):
     _LOGGER.debug(f"Service | Triggered action {call.service}")
     device = hass.data[DOMAIN][config_id][KEY_DEVICE]


### PR DESCRIPTION
### Related Issues

- Closes #117 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change retries all decorated function call or services after obtaining a new refreshed token, if necessary. These decorators have been applied to all calls made by the Alarm Panel and Services.

The set state decorator now handles all exceptions so that, in case of unexpected failure, the previous state is always reverted.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
1. Enable a long delay (e.g. 3600s)
2. Wait for 5 minutes (token expiration)
3. Run any action from the panel or call an arm/disarm service

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
This change doesn't have unit tests, hence why the code coverage decreased. While this is very sub-optimal for the code quality and reliability, we're working on the underlying implementation refactoring as the retry mechanism must be moved in `econnect-python`. This is necessary otherwise all library users have to implement the refresh token management, increasing heavily the code duplication.

As soon as this part is migrated, this code can be removed.

### Checklist

- [x] Related issues and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
