### PR TITLE
feat(service): add `update_state` service to force alarm updates

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -130,6 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     # as we need both to access the integration configurations.
     hass.services.async_register(DOMAIN, "arm_sectors", partial(services.arm_sectors, hass, config.entry_id))
     hass.services.async_register(DOMAIN, "disarm_sectors", partial(services.disarm_sectors, hass, config.entry_id))
+    hass.services.async_register(DOMAIN, "update_state", partial(services.update_state, hass, config.entry_id))
 
     for component in PLATFORMS:
         hass.async_create_task(hass.config_entries.async_forward_entry_setup(config, component))

--- a/custom_components/econnect_metronet/icons.json
+++ b/custom_components/econnect_metronet/icons.json
@@ -1,6 +1,7 @@
 {
     "services": {
         "arm_sectors": "mdi:shield-lock",
-        "disarm_sectors": "mdi:shield-off"
+        "disarm_sectors": "mdi:shield-off",
+        "update_state": "mdi:update"
     }
 }

--- a/custom_components/econnect_metronet/services.py
+++ b/custom_components/econnect_metronet/services.py
@@ -2,7 +2,7 @@ import logging
 
 from homeassistant.core import HomeAssistant, ServiceCall
 
-from .const import DOMAIN, KEY_DEVICE
+from .const import DOMAIN, KEY_COORDINATOR, KEY_DEVICE
 from .decorators import retry_refresh_token_service
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,3 +26,11 @@ async def disarm_sectors(hass: HomeAssistant, config_id: str, call: ServiceCall)
     code = call.data.get("code")
     _LOGGER.debug(f"Service | Disarming sectors: {sectors}")
     await hass.async_add_executor_job(device.disarm, code, sectors)
+
+
+@retry_refresh_token_service
+async def update_state(hass: HomeAssistant, config_id: str, call: ServiceCall):
+    _LOGGER.debug(f"Service | Triggered action {call.service}")
+    coordinator = hass.data[DOMAIN][config_id][KEY_COORDINATOR]
+    _LOGGER.debug("Service | Updating alarm state...")
+    await coordinator.async_refresh()

--- a/custom_components/econnect_metronet/services.yaml
+++ b/custom_components/econnect_metronet/services.yaml
@@ -1,5 +1,9 @@
 # Describes the format for available e-Connect services
 
+update_state:
+  name: Update Alarm State
+  description: Force an update of the alarm areas and inputs.
+
 arm_sectors:
   name: Arm Sectors
   description: Arm one or multiple sectors.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -57,3 +57,21 @@ async def test_service_disarm_sectors(hass, config_entry, alarm_device, coordina
     assert disarm.call_count == 1
     assert disarm.call_args[0][0] == "1234"
     assert disarm.call_args[0][1] == [1, 3]
+
+
+async def test_service_update_state(hass, config_entry, alarm_device, coordinator, mocker):
+    # Ensure `update_state` triggers a full refresh
+    update = mocker.patch.object(alarm_device, "update")
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "device": alarm_device,
+        "coordinator": coordinator,
+    }
+    call = ServiceCall(
+        domain=DOMAIN,
+        service="update_state",
+        data={},
+    )
+    # Test
+    await services.update_state(hass, config_entry.entry_id, call)
+    assert update.call_count == 1
+    assert update.call_args == ()


### PR DESCRIPTION
### Related Issues

- Closes #160 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Add `update_state` service so that users can trigger a full update manually (through lovelace dashboard) or programmatically (through automations).

#### Add the Update Button

Add a button in the Lovelace dashboard as follows:
1. Add a card of type "button".
2. In "Entity", select your Alarm Panel.
3. In "Tap Action", select "Call Service".
4. In "Service", select "e-Connect/Metronet Alarm: Update Alarm State".
5. Click "Save".

The screenshot below is a configuration example; update it based on your needs:
<img width="967" alt="image" src="https://github.com/palazzem/ha-econnect-alarm/assets/1560405/eb971b7d-ee09-4b84-bc95-ba0dbdb75de6">

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Trigger `update_state` service.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
