### PR TITLE
Fix alarm panel deprecations

### DIFF
--- a/custom_components/econnect_metronet/__init__.py
+++ b/custom_components/econnect_metronet/__init__.py
@@ -132,8 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry) -> bool:
     hass.services.async_register(DOMAIN, "disarm_sectors", partial(services.disarm_sectors, hass, config.entry_id))
     hass.services.async_register(DOMAIN, "update_state", partial(services.update_state, hass, config.entry_id))
 
-    for component in PLATFORMS:
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(config, component))
+    await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
 
     return True
 

--- a/custom_components/econnect_metronet/alarm_control_panel.py
+++ b/custom_components/econnect_metronet/alarm_control_panel.py
@@ -4,22 +4,14 @@ import logging
 
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
+    AlarmControlPanelState,
     CodeFormat,
 )
 from homeassistant.components.alarm_control_panel.const import (
     AlarmControlPanelEntityFeature as AlarmFeatures,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_USERNAME,
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMED_VACATION,
-    STATE_ALARM_ARMING,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_DISARMING,
-)
+from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -91,19 +83,19 @@ class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
         """Return the list of supported features."""
         return AlarmFeatures.ARM_HOME | AlarmFeatures.ARM_AWAY | AlarmFeatures.ARM_NIGHT | AlarmFeatures.ARM_VACATION
 
-    @set_device_state(STATE_ALARM_DISARMED, STATE_ALARM_DISARMING)
+    @set_device_state(AlarmControlPanelState.DISARMED, AlarmControlPanelState.DISARMING)
     @retry_refresh_token
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
         await self.hass.async_add_executor_job(self._device.disarm, code)
 
-    @set_device_state(STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMING)
+    @set_device_state(AlarmControlPanelState.ARMED_AWAY, AlarmControlPanelState.ARMING)
     @retry_refresh_token
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         await self.hass.async_add_executor_job(self._device.arm, code, self._device._sectors_away)
 
-    @set_device_state(STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMING)
+    @set_device_state(AlarmControlPanelState.ARMED_HOME, AlarmControlPanelState.ARMING)
     @retry_refresh_token
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
@@ -113,7 +105,7 @@ class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
 
         await self.hass.async_add_executor_job(self._device.arm, code, self._device._sectors_home)
 
-    @set_device_state(STATE_ALARM_ARMED_NIGHT, STATE_ALARM_ARMING)
+    @set_device_state(AlarmControlPanelState.ARMED_NIGHT, AlarmControlPanelState.ARMING)
     @retry_refresh_token
     async def async_alarm_arm_night(self, code=None):
         """Send arm night command."""
@@ -123,7 +115,7 @@ class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
 
         await self.hass.async_add_executor_job(self._device.arm, code, self._device._sectors_night)
 
-    @set_device_state(STATE_ALARM_ARMED_VACATION, STATE_ALARM_ARMING)
+    @set_device_state(AlarmControlPanelState.ARMED_VACATION, AlarmControlPanelState.ARMING)
     @retry_refresh_token
     async def async_alarm_arm_vacation(self, code=None):
         """Send arm vacation command."""

--- a/custom_components/econnect_metronet/alarm_control_panel.py
+++ b/custom_components/econnect_metronet/alarm_control_panel.py
@@ -69,7 +69,7 @@ class EconnectAlarm(CoordinatorEntity, AlarmControlPanelEntity):
         return "hass:shield-home"
 
     @property
-    def state(self):
+    def alarm_state(self):
         """Return the state of the device."""
         return self._device.state
 

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -11,7 +11,6 @@ from elmo.api.exceptions import (
     ParseError,
 )
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
-from homeassistant.const import STATE_UNAVAILABLE
 from requests.exceptions import HTTPError
 
 from .const import (
@@ -64,7 +63,7 @@ class AlarmDevice:
         self._sectors_vacation = config.get(CONF_AREAS_ARM_VACATION) or []
 
         # Alarm state
-        self.state = STATE_UNAVAILABLE
+        self.state = None
 
     def _register_sector(self, entity):
         """Register a sector entity in the device's internal inventory."""

--- a/custom_components/econnect_metronet/devices.py
+++ b/custom_components/econnect_metronet/devices.py
@@ -10,16 +10,8 @@ from elmo.api.exceptions import (
     LockError,
     ParseError,
 )
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMED_VACATION,
-    STATE_ALARM_ARMING,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_DISARMING,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import STATE_UNAVAILABLE
 from requests.exceptions import HTTPError
 
 from .const import (
@@ -225,12 +217,12 @@ class AlarmDevice:
         """
         # If the system is arming or disarming, return the current state
         # to prevent the state from being updated while the system is in transition.
-        if self.state in [STATE_ALARM_ARMING, STATE_ALARM_DISARMING]:
+        if self.state in [AlarmControlPanelState.ARMING, AlarmControlPanelState.DISARMING]:
             return self.state
 
         sectors_armed = dict(self.items(q.SECTORS, status=True))
         if not sectors_armed:
-            return STATE_ALARM_DISARMED
+            return AlarmControlPanelState.DISARMED
 
         # Note: `element` is the sector ID you use to arm/disarm the sector.
         sectors = [sectors["element"] for sectors in sectors_armed.values()]
@@ -238,15 +230,15 @@ class AlarmDevice:
         # regardless of whether the input lists were pre-sorted or not.
         sectors_armed_sorted = sorted(sectors)
         if sectors_armed_sorted == sorted(self._sectors_home):
-            return STATE_ALARM_ARMED_HOME
+            return AlarmControlPanelState.ARMED_HOME
 
         if sectors_armed_sorted == sorted(self._sectors_night):
-            return STATE_ALARM_ARMED_NIGHT
+            return AlarmControlPanelState.ARMED_NIGHT
 
         if sectors_armed_sorted == sorted(self._sectors_vacation):
-            return STATE_ALARM_ARMED_VACATION
+            return AlarmControlPanelState.ARMED_VACATION
 
-        return STATE_ALARM_ARMED_AWAY
+        return AlarmControlPanelState.ARMED_AWAY
 
     def get_status(self, query: int, id: int) -> Union[bool, int]:
         """Get the status of an item in the device inventory specified by query and id.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "pytest-socket",
   "requests-mock",
   "syrupy",
+  "respx",
 ]
 
 lint = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 import responses
 from elmo.api.client import ElmoClient
+from homeassistant.config_entries import ConfigEntryState
 
 from custom_components.econnect_metronet import async_setup
 from custom_components.econnect_metronet.alarm_control_panel import EconnectAlarm
@@ -164,6 +165,7 @@ def config_entry(hass):
             "domain": "econnect_metronet",
             "system_base_url": "https://example.com",
         },
+        state=ConfigEntryState.SETUP_IN_PROGRESS,
     )
     config.add_to_hass(hass)
     return config

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -2,16 +2,8 @@ import pytest
 import responses
 from elmo import query as q
 from elmo.api.exceptions import CodeError, CredentialError, LockError, ParseError
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMED_VACATION,
-    STATE_ALARM_ARMING,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_DISARMING,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import STATE_UNAVAILABLE
 from requests.exceptions import HTTPError
 from requests.models import Response
 
@@ -1468,7 +1460,7 @@ def test_get_state_no_sectors_armed(alarm_device):
     alarm_device._sectors_night = []
     alarm_device._inventory = {9: {}}
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_DISARMED
+    assert alarm_device.get_state() == AlarmControlPanelState.DISARMED
 
 
 def test_get_state_armed_home(alarm_device):
@@ -1482,7 +1474,7 @@ def test_get_state_armed_home(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_HOME
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_HOME
 
 
 def test_get_state_armed_home_out_of_order(alarm_device):
@@ -1496,7 +1488,7 @@ def test_get_state_armed_home_out_of_order(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_HOME
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_HOME
 
 
 def test_get_state_armed_night(alarm_device):
@@ -1510,7 +1502,7 @@ def test_get_state_armed_night(alarm_device):
         }
     }
     # Test (out of order keys to test sorting)
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_NIGHT
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_NIGHT
 
 
 def test_get_state_armed_night_out_of_order(alarm_device):
@@ -1524,7 +1516,7 @@ def test_get_state_armed_night_out_of_order(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_NIGHT
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_NIGHT
 
 
 def test_get_state_armed_vacation(alarm_device):
@@ -1538,7 +1530,7 @@ def test_get_state_armed_vacation(alarm_device):
         }
     }
     # Test (out of order keys to test sorting)
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_VACATION
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_VACATION
 
 
 def test_get_state_armed_vacation_out_of_order(alarm_device):
@@ -1552,7 +1544,7 @@ def test_get_state_armed_vacation_out_of_order(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_VACATION
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_VACATION
 
 
 def test_get_state_armed_away(alarm_device):
@@ -1569,7 +1561,7 @@ def test_get_state_armed_away(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_AWAY
 
 
 def test_get_state_armed_mixed(alarm_device):
@@ -1586,7 +1578,7 @@ def test_get_state_armed_mixed(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_AWAY
 
 
 def test_get_state_armed_away_with_config(alarm_device):
@@ -1603,7 +1595,7 @@ def test_get_state_armed_away_with_config(alarm_device):
         }
     }
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMED_AWAY
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMED_AWAY
 
 
 def test_get_state_while_disarming(alarm_device):
@@ -1612,9 +1604,9 @@ def test_get_state_while_disarming(alarm_device):
     alarm_device._sectors_home = []
     alarm_device._sectors_night = []
     alarm_device._inventory = {9: {}}
-    alarm_device.state = STATE_ALARM_DISARMING
+    alarm_device.state = AlarmControlPanelState.DISARMING
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_DISARMING
+    assert alarm_device.get_state() == AlarmControlPanelState.DISARMING
 
 
 def test_get_state_while_arming(alarm_device):
@@ -1623,9 +1615,9 @@ def test_get_state_while_arming(alarm_device):
     alarm_device._sectors_home = []
     alarm_device._sectors_night = []
     alarm_device._inventory = {9: {}}
-    alarm_device.state = STATE_ALARM_ARMING
+    alarm_device.state = AlarmControlPanelState.ARMING
     # Test
-    assert alarm_device.get_state() == STATE_ALARM_ARMING
+    assert alarm_device.get_state() == AlarmControlPanelState.ARMING
 
 
 class TestTurnOff:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -3,7 +3,6 @@ import responses
 from elmo import query as q
 from elmo.api.exceptions import CodeError, CredentialError, LockError, ParseError
 from homeassistant.components.alarm_control_panel import AlarmControlPanelState
-from homeassistant.const import STATE_UNAVAILABLE
 from requests.exceptions import HTTPError
 from requests.models import Response
 
@@ -34,7 +33,7 @@ def test_device_constructor(client):
     assert device._sectors_home == []
     assert device._sectors_night == []
     assert device._sectors_vacation == []
-    assert device.state == STATE_UNAVAILABLE
+    assert device.state is None
 
 
 def test_device_constructor_with_config(client):
@@ -58,7 +57,7 @@ def test_device_constructor_with_config(client):
     assert device._sectors_home == [3, 4]
     assert device._sectors_night == [1, 2, 3]
     assert device._sectors_vacation == [5, 3]
-    assert device.state == STATE_UNAVAILABLE
+    assert device.state is None
 
 
 def test_device_constructor_with_config_empty(client):
@@ -82,7 +81,7 @@ def test_device_constructor_with_config_empty(client):
     assert device._sectors_home == []
     assert device._sectors_night == []
     assert device._sectors_vacation == []
-    assert device.state == STATE_UNAVAILABLE
+    assert device.state is None
 
 
 class TestItemInputs:


### PR DESCRIPTION
### Related Issues

- #169 

### Proposed Changes:
I recently started to look into this component and noticed that it is notifying a few deprecations, so I thought I could help fixing those

### Testing:
This only relates to HA changes so no new test is needed (in my opinion)

### Extra Notes (optional):
The deprecations I fixed are:
- Added respx package, otherwise tests were not running at all (I believe this was introduced in HA 2014.8), commit 8a78ef379b9a108b30d8fa526d9d1421b9819403
- STATE_ALARM_ARMED_AWAY was used from <pacakge>, this is a deprecated constant which will be removed in HA Core 2025.11. Use AlarmControlPanelState.ARMED_AWAY instead (fixed in commit 96c62d746d71c8f00520066f8f97a1ea0e97e9c9)
- Detected code that uses `async_config_entry_first_refresh`, which is only supported when entry state is ConfigEntryState.SETUP_IN_PROGRESS, but it is in state ConfigEntryState.NOT_LOADED, This will stop working in Home Assistant 2025.11 (fixed in b709f136d61f8ed1cfe1940303320018129388b7)
- Detected that custom integration<pacakge> calls async_forward_entry_setup for integration, econnect_metronet with title: e-Connect/Metronet Alarm and entry_id: <ID>, which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead at custom_components/econnect_metronet/__init__.py, line 136 (fixed in commit 5b07471e61079ae81f5064420427d4f9a5892913)
- <class 'custom_components.econnect_metronet.alarm_control_panel.EconnectAlarm'>) is setting state directly which will stop working in HA Core 2025.11. Entities should implement the 'alarm_state' property and return its state using the AlarmControlPanelState enum, please report it to the custom integration author (fixed in commit 65118ca04f135207e8f1966d48601aed27f49bdf)

One thing I was not sure about (but figured out I would try and if you don't agree I could go back and fix it) is about "Fix alarm_state deprecation for HA Core 2025.11". Before my changes the state was "unavailable" before the first state update. Now it is None (we can now only return enum values defined in `AlarmControlPanelState`, and there is no value for unedefined).
Is it ok for you?

### Checklist

- [ ] Related issues and proposed changes are filled
- [ ] Tests are defining the correct and expected behavior
- [ ] Code is well-documented via docstrings
