### PR TITLE
fix(client): update `econnect-python` to support backend long-polling

### DIFF
--- a/custom_components/econnect_metronet/manifest.json
+++ b/custom_components/econnect_metronet/manifest.json
@@ -10,6 +10,6 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/palazzem/ha-econnect-alarm/issues",
     "loggers": ["custom_components.econnect_metronet", "elmo"],
-    "requirements": ["econnect-python==0.12.0"],
+    "requirements": ["econnect-python==0.14.0"],
     "version": "2.4.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "econnect-python==0.12.0",
+  "econnect-python==0.14.0",
   "async_timeout",
   "homeassistant",
 ]


### PR DESCRIPTION
### Related Issues

- Fixes #180 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change updates `econnect-python` library with version `0.14.0`. Changes that are fixing the underlying problem of the integration are:
* Sectors, inputs and outputs `last_id` values are retrieved properly (https://github.com/palazzem/econnect-python/pull/156)
* Use e-Connect web login to register clients with Cloud API long-polling (https://github.com/palazzem/econnect-python/pull/161)
* Use web login access token when `Redirect` URL is followed, keeping long-polling active (https://github.com/palazzem/econnect-python/pull/163)

Full release notes are available here: https://github.com/palazzem/econnect-python/releases/tag/v0.14.0

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
