### PR TITLE
fix(entity): `split_code` returns a `user_id=1` if the code is lesser than 7 digits

### DIFF
--- a/custom_components/econnect_metronet/helpers.py
+++ b/custom_components/econnect_metronet/helpers.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Tuple, Union
 
 import voluptuous as vol
@@ -8,6 +9,8 @@ from homeassistant.helpers.config_validation import multi_select
 from homeassistant.util import slugify
 
 from .const import CONF_SYSTEM_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class select(multi_select):
@@ -101,8 +104,12 @@ def split_code(code: str) -> Tuple[str, str]:
         CodeError: If the input code is less than 7 characters long, indicating it does not
         conform to the expected format.
     """
-    if len(code) <= 6:
+    if not code:
         raise CodeError("Your code must be in the format <USER_ID><CODE> without spaces.")
+
+    if len(code) < 7:
+        _LOGGER.debug("Client | Your configuration may require a code in the format <USER_ID><CODE> without spaces.")
+        return "1", code
 
     user_id_part, code_part = code[:-6], code[-6:]
     if not (user_id_part.isdigit() and code_part.isdigit()):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1283,7 +1283,7 @@ def test_device_arm_code_error_with_user_id(alarm_device, mocker):
     # Test
     alarm_device._connection._session_id = "test"
     with pytest.raises(CodeError):
-        alarm_device.arm("1234", sectors=[4])
+        alarm_device.arm("asdf1234", sectors=[4])
 
 
 def test_device_arm_error(client, mocker):
@@ -1408,7 +1408,7 @@ def test_device_disarm_code_error_with_user_id(alarm_device, mocker):
     # Test
     alarm_device._connection._session_id = "test"
     with pytest.raises(CodeError):
-        alarm_device.disarm("1234", sectors=[4])
+        alarm_device.disarm("asdf1234", sectors=[4])
 
 
 def test_device_disarm_error(client, mocker):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from elmo.api.exceptions import CodeError
 from homeassistant.core import valid_entity_id
@@ -57,12 +59,13 @@ def test_split_code_with_valid_digits():
     assert split_code(code) == ("123456", "789012")
 
 
-def test_split_code_with_exact_six_chars_raises_error():
-    # Should raise CodeError for code with less than 7 characters
-    code = "123456"
-    with pytest.raises(CodeError) as exc_info:
-        split_code(code)
-    assert "format <USER_ID><CODE> without spaces" in str(exc_info.value)
+def test_split_code_with_exact_six_chars_raises_error(caplog):
+    # Should log a debug message and return a tuple with user ID 1 and the code
+    caplog.set_level(logging.DEBUG)
+    assert split_code("123456") == ("1", "123456")
+    debug_msg = [record for record in caplog.records if record.levelname == "DEBUG"]
+    assert len(debug_msg) == 1
+    assert "format <USER_ID><CODE> without spaces" in debug_msg[0].message
 
 
 def test_split_code_with_alphanumeric_user_id_raises_error():


### PR DESCRIPTION
### Related Issues

- Fixes #176 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Recent firmware updates to the central unit allow user identification based on inserted PIN, even if the `user_id` is not explicitly provided. Since this lookup is now handled internally by the unit, specifying a combined `<USER_ID><CODE>` is no longer necessary. By default, the system can safely assume `user_id = "1"` when it's omitted.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Arm or disarm the alarm without selecting your `<USER_ID>`.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
