### PR TITLE
fix: update current tests to prevent incorrect `ContextVar` usage

### DIFF
--- a/tests/test_alarm_panel.py
+++ b/tests/test_alarm_panel.py
@@ -10,7 +10,9 @@ from custom_components.econnect_metronet.devices import AlarmDevice
 def test_alarm_panel_name(client, hass, config_entry):
     # Ensure the Alarm Panel has the right name
     device = AlarmDevice(client)
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+    coordinator = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+    )
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
     assert entity.name == "Alarm Panel test_user"
 
@@ -19,7 +21,9 @@ def test_alarm_panel_name_with_system_name(client, hass, config_entry):
     # Ensure the Entity ID takes into consideration the system optional name
     hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     device = AlarmDevice(client)
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+    coordinator = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+    )
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
     assert entity.name == "Alarm Panel Home"
 
@@ -27,7 +31,9 @@ def test_alarm_panel_name_with_system_name(client, hass, config_entry):
 def test_alarm_panel_entity_id(client, hass, config_entry):
     # Ensure the Alarm Panel has a valid Entity ID
     device = AlarmDevice(client)
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+    coordinator = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+    )
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
     assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user"
 
@@ -36,7 +42,9 @@ def test_alarm_panel_entity_id_with_system_name(client, hass, config_entry):
     # Ensure the Entity ID takes into consideration the system name
     hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
     device = AlarmDevice(client)
-    coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+    coordinator = DataUpdateCoordinator(
+        hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+    )
     entity = EconnectAlarm("test_id", config_entry, device, coordinator)
     assert entity.entity_id == "econnect_metronet.econnect_metronet_home"
 

--- a/tests/test_binary_sensors.py
+++ b/tests/test_binary_sensors.py
@@ -97,77 +97,101 @@ async def test_async_setup_entry_alerts_unique_id(hass, config_entry, alarm_devi
 class TestAlertBinarySensor:
     def test_binary_sensor_is_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("device_tamper", 7, config_entry, "device_tamper", coordinator, alarm_device)
         assert entity.is_on is True
 
     def test_binary_sensor_is_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("device_failure", 2, config_entry, "device_failure", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_missing(self, hass, config_entry, alarm_device):
         # Ensure the sensor raise keyerror if the alert is missing
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
         with pytest.raises(KeyError):
             assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_anomalies_led_is_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
         alarm_device._inventory[11][1]["status"] = 2
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("anomalies_led", 1, config_entry, "anomalies_led", coordinator, alarm_device)
         assert entity.is_on is True
 
     def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right translation key
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.translation_key == "has_anomalies"
 
     def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has a valid Entity ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_has_anomalies"
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_has_anomalies"
 
     def test_binary_sensor_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right unique ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.icon == "hass:alarm-light"
 
     def test_binary_sensor_device_class(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right device class
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertBinarySensor("test_id", 0, config_entry, "has_anomalies", coordinator, alarm_device)
         assert entity.device_class == "problem"
 
@@ -175,51 +199,67 @@ class TestAlertBinarySensor:
 class TestInputBinarySensor:
     def test_binary_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.name == "1 Tamper Sirena"
 
     def test_binary_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_tamper_sirena"
 
     def test_binary_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_tamper_sirena"
 
     def test_binary_sensor_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right unique ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "1 Tamper Sirena", coordinator, alarm_device)
         assert entity.icon == "hass:electric-switch"
 
     def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 2, config_entry, "Outdoor Sensor 2", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = InputBinarySensor("test_id", 1, config_entry, "Outdoor Sensor 1", coordinator, alarm_device)
         assert entity.is_on is True
 
@@ -227,56 +267,74 @@ class TestInputBinarySensor:
 class TestSectorBinarySensor:
     def test_binary_sensor_device_class(self, hass, config_entry, alarm_device):
         # Ensure sectors provide the device class name
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.device_class == "sector"
 
     def test_binary_sensor_input_name(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right name
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.name == "1 S1 Living Room"
 
     def test_binary_sensor_input_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has a valid Entity ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_1_s1_living_room"
 
     def test_binary_sensor_input_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_1_s1_living_room"
 
     def test_binary_sensor_input_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right unique ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "1 S1 Living Room", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_binary_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.icon == "hass:shield-home-outline"
 
     def test_binary_sensor_off(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status False
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 2, config_entry, "S3 Outdoor", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_binary_sensor_on(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute is_on has the right status True
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = SectorBinarySensor("test_id", 1, config_entry, "S2 Bedroom", coordinator, alarm_device)
         assert entity.is_on is True

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -40,51 +40,67 @@ async def test_async_setup_entry_alerts_unique_id(hass, config_entry, alarm_devi
 class TestAlertSensor:
     def test_sensor_native_value(self, hass, config_entry, alarm_device):
         # Ensure the sensor attribute native_value has the right status
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 16, config_entry, "input_led", coordinator, alarm_device)
         assert entity.native_value == 2
 
     def test_sensor_missing(self, hass, config_entry, alarm_device):
         # Ensure the sensor raise keyerror if the alert is missing
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 1000, config_entry, "test_id", coordinator, alarm_device)
         with pytest.raises(KeyError):
             assert entity.native_value == 1
 
     def test_sensor_name(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right translation key
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 16, config_entry, "input_led", coordinator, alarm_device)
         assert entity.translation_key == "input_led"
 
     def test_binary_sensor_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the translation key
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.translation_key == "input_led"
 
     def test_sensor_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has a valid Entity ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_input_led"
 
     def test_sensor_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_input_led"
 
     def test_sensor_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the alert has the right unique ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_sensor_icon(self, hass, config_entry, alarm_device):
         # Ensure the sensor has the right icon
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = AlertSensor("test_id", 0, config_entry, "input_led", coordinator, alarm_device)
         assert entity.icon == "hass:alarm-light"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -56,50 +56,66 @@ async def test_async_setup_entry_outputs_unique_id(hass, config_entry, alarm_dev
 class TestOutputSwitch:
     def test_switch_name(self, hass, config_entry, alarm_device):
         # Ensure the switch has the right name
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.name == "Output 2"
 
     def test_switch_name_with_system_name(self, hass, config_entry, alarm_device):
         # The system name doesn't change the Entity name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.name == "Output 2"
 
     def test_switch_entity_id(self, hass, config_entry, alarm_device):
         # Ensure the switch has a valid Entity ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_test_user_output_2"
 
     def test_switch_entity_id_with_system_name(self, hass, config_entry, alarm_device):
         # Ensure the Entity ID takes into consideration the system name
         hass.config_entries.async_update_entry(config_entry, data={"system_name": "Home"})
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.entity_id == "econnect_metronet.econnect_metronet_home_output_2"
 
     def test_switch_unique_id(self, hass, config_entry, alarm_device):
         # Ensure the switch has the right unique ID
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.unique_id == "test_id"
 
     def test_switch_icon(self, hass, config_entry, alarm_device):
         # Ensure the switch has the right icon
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 2", coordinator, alarm_device)
         assert entity.icon == "hass:toggle-switch-variant"
 
     def test_switch_is_off(self, hass, config_entry, alarm_device):
         # Ensure the switch attribute is_on has the right status False
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 2, config_entry, "Output 3", coordinator, alarm_device)
         assert entity.is_on is False
 
     def test_switch_is_on(self, hass, config_entry, alarm_device):
         # Ensure the switch attribute is_on has the right status True
-        coordinator = DataUpdateCoordinator(hass, logging.getLogger(__name__), name="econnect_metronet")
+        coordinator = DataUpdateCoordinator(
+            hass, logging.getLogger(__name__), config_entry=config_entry, name="econnect_metronet"
+        )
         entity = OutputSwitch("test_id", 1, config_entry, "Output 1", coordinator, alarm_device)
         assert entity.is_on is True


### PR DESCRIPTION
## Summary

This PR addresses "Detected code that relies on ContextVar" warnings in the test suite by properly initializing DataUpdateCoordinator instances with the required `config_entry` parameter. These errors were occurring because ContextVar requires proper Home Assistant configuration context when instantiating coordinators.

The changes apply a consistent pattern across all test fixtures that instantiate DataUpdateCoordinator, ensuring proper context setup in test environments.

## Changes

Updated 4 test files with 48 total coordinator instantiation fixes:

- tests/test_alarm_panel.py: 4 fixes for alarm panel test cases
- tests/test_binary_sensors.py: 20 fixes across AlertBinarySensor, InputBinarySensor, and SectorBinarySensor test classes
- tests/test_sensors.py: 8 fixes for alert sensor test cases
- tests/test_switch.py: 8 fixes for output switch test cases

Each fix adds `config_entry=config_entry` parameter to the DataUpdateCoordinator initialization, providing the necessary Home Assistant configuration context.

## Testing

These are test-only changes with no impact to production code. All existing test assertions remain unchanged - only the coordinator initialization pattern was updated. The fixes eliminate spurious ContextVar errors that were obscuring actual test results.

## Notes

No production code was modified. This is purely a test suite improvement to align with Home Assistant testing best practices.